### PR TITLE
Save B_mrg_it2 as bl and update reference in fx generate_videos

### DIFF
--- a/minian/visualization.py
+++ b/minian/visualization.py
@@ -1169,12 +1169,12 @@ def generate_videos(minian, vpath, chk=None, pre_compute=False):
     C = minian['C'].chunk(dict(frame=chk['frame'], unit_id=-1))
     Y = minian['Y'].chunk(dict(frame=chk['frame'], height=chk['height'], width=chk['width']))
     try:
-        B = minian['B'].chunk(dict(unit_id=-1))
+        bl = minian['bl'].chunk(dict(unit_id=-1))
     except KeyError:
         print("cannot find background term")
-        B = 0
+        bl = 0
     org = minian['org'].chunk(dict(frame=chk['frame'], height=chk['height'], width=chk['width']))
-    C = C + B
+    C = C + bl
     AC = xr.apply_ufunc(
         da.dot, A, C,
         input_core_dims=[['height', 'width', 'unit_id'], ['unit_id', 'frame']],

--- a/pipeline.ipynb
+++ b/pipeline.ipynb
@@ -1535,7 +1535,7 @@
     "save_minian(S_mrg_it2.rename('S'), **param_save_minian)\n",
     "save_minian(g_mrg_it2.rename('g'), **param_save_minian)\n",
     "save_minian(C0_mrg_it2.rename('C0'), **param_save_minian)\n",
-    "save_minian(B_mrg_it2.rename('B'), **param_save_minian)\n",
+    "save_minian(B_mrg_it2.rename('bl'), **param_save_minian)\n",
     "save_minian(b_spatial_it2.rename('b'), **param_save_minian)\n",
     "save_minian(f_spatial_it2.rename('f'), **param_save_minian)"
    ]
@@ -1606,9 +1606,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python3 (minian)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "minian"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
`B_mrg_it2` was saved as `B`, which was in conflict with `b_spatial_it2` being saved as `b`.  `B` was being overwritten by `b`.  Changed saving of `B_mrg_it2` to `bl` in order to avoid this issue and amended code in fx `generate_videos` to reflect this change.  