### PR TITLE
Permit loading mkv videos as well

### DIFF
--- a/minian/utilities.py
+++ b/minian/utilities.py
@@ -116,7 +116,7 @@ def load_videos(vpath,
     print("loading {} videos in folder {}".format(len(vlist), vpath))
 
     file_extension = os.path.splitext(vlist[0])[1]
-    if file_extension == '.avi':
+    if file_extension in ('.avi', '.mkv'):
         movie_load_func = load_avi_lazy
     elif file_extension == '.tif':
         movie_load_func = load_tif_lazy


### PR DESCRIPTION
Hi!
Thank you for creating Minian! Our [PoMiDAQ](https://github.com/bothlab/pomidaq) data acquisition software generates FFV1-encoded Matroska video files by default (to greatly reduce the size of stored videos while not loosing quality and using patent-free open-source codecs). Minian loads these just fine, and data analysis seems to work well in preliminary tests with short sample data.

So, we are using the attached patch to load MKV videos as well.
Cheers,
    Matthias