### PR TITLE
fix: avoid conversion in `xrconcat_recursive`

### DIFF
--- a/minian/motion_correction.py
+++ b/minian/motion_correction.py
@@ -699,7 +699,7 @@ def apply_transform(
         Movie data after transform.
     """
     sh_dim = trans.coords["shift_dim"].values.tolist()
-    if trans.ndim > 2:
+    if "grid0" in trans.dims:
         fm0 = varr.isel(frame=0).values
         if mesh_size is None:
             mesh_size = get_mesh_size(fm0)

--- a/minian/utilities.py
+++ b/minian/utilities.py
@@ -585,8 +585,11 @@ def xrconcat_recursive(var: Union[dict, list], dims: List[str]) -> xr.Dataset:
             var_dict = {k: v.to_dataset() for k, v in var_dict.items()}
         except AttributeError:
             pass
-        var_ps = pd.Series(var_dict)
-        var_ps.index.set_names(dims, inplace=True)
+        data = np.empty(len(var_dict), dtype=object)
+        for iv, ds in enumerate(var_dict.values()):
+            data[iv] = ds
+        index = pd.MultiIndex.from_tuples(list(var_dict.keys()), names=dims)
+        var_ps = pd.Series(data=data, index=index)
         xr_ls = []
         for idx, v in var_ps.groupby(level=dims[0]):
             v.index = v.index.droplevel(dims[0])


### PR DESCRIPTION
When constructing series holding xarray datasets the internal conversion of numpy would result in error.
This PR fix it.