### PR TITLE
Pinning FFTW version

### DIFF
--- a/requirements/requirements-base.txt
+++ b/requirements/requirements-base.txt
@@ -16,7 +16,7 @@ numpy==1.20.2
 opencv-python==4.2.0.34
 pandas==1.2.3
 panel==0.8.0
-pyfftw>=0.12.0
+pyfftw==0.12.0
 scikit-image==0.18.1
 scikit-learn==0.22.1
 scipy>=1.4.1


### PR DESCRIPTION
Experienced an issue after setup when 0.13.0 of pyFFTW was released.  If we pin to 0.12.0 this seems like it won't happen