### PR TITLE
Get correct frame amount for video files without nb_frames property & allow codec selection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ demo_movies export-ignore
 .readthedocs.yaml export-ignore
 codecov.yml export-ignore
 .github export-ignore
+demo_movies/*.mkv filter=lfs diff=lfs merge=lfs -text

--- a/demo_movies/sample1.mkv
+++ b/demo_movies/sample1.mkv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebea009f040f900b59732552616805e9a6e9c4ddf173d26a10ac4d30f388ef70
+size 156097649

--- a/minian/utilities.py
+++ b/minian/utilities.py
@@ -225,7 +225,15 @@ def load_avi_lazy(fname: str) -> darr.array:
     video_info = next(s for s in probe["streams"] if s["codec_type"] == "video")
     w = int(video_info["width"])
     h = int(video_info["height"])
-    f = int(video_info["nb_frames"])
+    if "nb_frames" in video_info:
+        f = int(video_info["nb_frames"])
+    else:
+        r_fps = video_info["r_frame_rate"]
+        num, denom = r_fps.split("/")
+        fps = float(num) / float(denom)
+        f = float(probe["format"]["duration"]) * fps
+        f = np.round(f).astype(int)
+
     return da.array.from_delayed(
         da.delayed(load_avi_ffmpeg)(fname, h, w, f), dtype=np.uint8, shape=(f, h, w)
     )

--- a/minian/utilities.py
+++ b/minian/utilities.py
@@ -265,6 +265,7 @@ def load_avi_ffmpeg(fname: str, h: int, w: int, f: int) -> np.ndarray:
     out_bytes, err = (
         ffmpeg.input(fname)
         .video.output("pipe:", format="rawvideo", pix_fmt="gray")
+        .global_args("-hide_banner", "-nostats")
         .run(capture_stdout=True)
     )
     return np.frombuffer(out_bytes, np.uint8).reshape(f, h, w)


### PR DESCRIPTION
**[This is a new PR due to a source-branch change, following up #193 - the original PR text is reproduced below for reference]**

Hi!
First of all, I'm really impressed by this project! Two years ago, it was a bit mediocre compared to MIN1PIPE, but now based on very early testing, Minian seems to outperform CaImAn and MIN1PIPE for my datasets! (Still need a lot more testing for that though, I wonder whether switching out Minian's median filter with an anisotropic filter for denoising would make things even better...)
The best thing is that Minian's documentation is excellent, which makes it very easy to get started, and all public API seems to be well documented as well. Really awesome work!

The data I generate is recorded with [PoMiDAQ](https://github.com/bothlab/pomidaq) or [Syntalos](https://github.com/bothlab/syntalos), which prefer the MKV container for video, as it's a bit nicer to store FFV1 video in, but more importantly I use MKV's ability to save arbitrary metadata with the video file quite excessively.
When loading these files into Minian, it currently crashes as the `nb_frames` property apparently doesn't exist for MKV containers. Fortunately, the amount of frames is very easy to calculate, so this patch adds support for just that!

Thanks for considering the change! :-)
Cheers,
    Matthias
