### PR TITLE
Add standalone pipeline modules and separation judgement tooling

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -42,3 +42,4 @@ dependencies:
   - rechunker=0.3.3
   - medpy=0.4.0
   - jinja2=2.11.3
+  - markupsafe=2.0.1

--- a/minian/test/toy_data.py
+++ b/minian/test/toy_data.py
@@ -141,8 +141,8 @@ def generate_data(
             a_min=-2 * mo_sigma,
             a_max=2 * mo_sigma,
         ),
-        dims=["frame", "variable"],
-        coords={"frame": np.arange(ff), "variable": ["height", "width"]},
+        dims=["frame", "shift_dim"],
+        coords={"frame": np.arange(ff), "shift_dim": ["height", "width"]},
         name="shifts",
     )
     Y = (
@@ -170,7 +170,7 @@ if __name__ == "__main__":
     # optimal parameters
     param_denoise = {"method": "median", "ksize": 7}
     param_background_removal = {"method": "tophat", "wnd": 15}
-    param_estimate_shift = {"dim": "frame", "max_sh": 20}
+    param_estimate_motion = {"dim": "frame", "max_sh": 20}
     param_seeds_init = {
         "wnd_size": 100,
         "method": "rolling",
@@ -236,9 +236,7 @@ if __name__ == "__main__":
     for dat in [Y, Y_true, A, C, S, shifts]:
         save_minian(
             dat,
-            dpath=testpath,
-            fname="minian",
-            backend="zarr",
+            dpath=os.path.join(testpath, "minian"),
             meta_dict={"session": -1, "animal": -2},
             overwrite=True,
         )
@@ -247,14 +245,12 @@ if __name__ == "__main__":
     Y_glow = (Y - Y.min("frame").compute()).rename("Y_glow")
     Y_dn = denoise(Y_glow, **param_denoise).rename("Y_denoise")
     Y_bg = remove_background(Y_dn, **param_background_removal).rename("Y_bg")
-    shifts_est = estimate_shifts(Y_bg, **param_estimate_shift)
-    Y_mc = apply_shifts(Y_bg, shifts_est).fillna(0).rename("Y_mc")
+    shifts_est = estimate_motion(Y_bg, **param_estimate_motion)
+    Y_mc = apply_shifts(Y_bg.astype(float), shifts_est).fillna(0).rename("Y_mc")
     for dat in [Y_glow, Y_dn, Y_bg, Y_mc, shifts_est]:
         save_minian(
             dat,
-            dpath=testpath,
-            fname="minian",
-            backend="zarr",
+            dpath=os.path.join(testpath, "minian"),
             meta_dict={"session": -1, "animal": -2},
             overwrite=True,
         )
@@ -299,9 +295,7 @@ if __name__ == "__main__":
     ]:
         save_minian(
             dat,
-            dpath=testpath,
-            fname="minian",
-            backend="zarr",
+            dpath=os.path.join(testpath, "minian"),
             meta_dict={"session": -1, "animal": -2},
             overwrite=True,
         )

--- a/separation/MODULE_CHAIN_CONTRACT.md
+++ b/separation/MODULE_CHAIN_CONTRACT.md
@@ -1,0 +1,168 @@
+# Module Chain Contract (4-Module Separation)
+
+This repository validates a 4-stage separated chain for MiniAn CNMF calcium imaging:
+
+1. `preprocessing`: raw video directory -> background-removed video + chunk sizes
+2. `motion_correction`: preprocessed video -> motion-corrected video in two chunk layouts
+3. `source_detection`: motion-corrected video -> CNMF spatial/temporal components (A, C, S, b, f, b0, c0)
+4. `component_filtering`: CNMF outputs -> filtered components with quality metrics
+
+## Module Signatures
+
+### Module 1: preprocessing
+
+```python
+def preprocess_video(dpath: str, config: dict) -> Tuple[xr.DataArray, dict, dict]:
+    """
+    Args:
+        dpath: Path to directory containing raw video files (AVI).
+        config: Dict with keys: param_load_videos, param_denoise,
+                param_background_removal, intpath, subset.
+
+    Returns:
+        Y_bg: Background-removed, denoised video (xr.DataArray, dims: frame/height/width).
+        chk: Chunk size dict with keys 'frame', 'height', 'width'.
+        config_out: Merged config including chk, intpath, dpath for downstream modules.
+    """
+```
+
+### Module 2: motion_correction
+
+```python
+def correct_motion(
+    Y_bg: xr.DataArray, config: dict
+) -> Tuple[xr.DataArray, xr.DataArray, xr.DataArray, xr.DataArray, dict]:
+    """
+    Args:
+        Y_bg: Preprocessed video from Module 1.
+        config: Dict with keys: param_estimate_motion, subset_mc, chk, intpath,
+                param_save_minian.
+
+    Returns:
+        Y_hw_chk: Motion-corrected video, spatial-chunked (frame=-1, height=chk, width=chk).
+        Y_fm_chk: Motion-corrected video, frame-chunked (frame=chk, height=-1, width=-1).
+        motion: Estimated motion shifts (xr.DataArray, dims: frame/shift_dim).
+        max_proj: Maximum projection of corrected video (xr.DataArray, dims: height/width).
+        config_out: Merged config for downstream.
+    """
+```
+
+### Module 3: source_detection
+
+```python
+def detect_sources(
+    Y_hw_chk: xr.DataArray,
+    Y_fm_chk: xr.DataArray,
+    max_proj: xr.DataArray,
+    config: dict,
+) -> Tuple[xr.DataArray, xr.DataArray, xr.DataArray, xr.DataArray,
+           xr.DataArray, xr.DataArray, xr.DataArray, dict]:
+    """
+    Args:
+        Y_hw_chk: Spatial-chunked video from Module 2.
+        Y_fm_chk: Frame-chunked video from Module 2.
+        max_proj: Maximum projection from Module 2.
+        config: Dict with all CNMF parameters (param_seeds_init, param_pnr_refine,
+                param_ks_refine, param_seeds_merge, param_initialize, param_init_merge,
+                param_get_noise, param_first_spatial, param_first_temporal,
+                param_first_merge, param_second_spatial, param_second_temporal,
+                chk, intpath, param_save_minian).
+
+    Returns:
+        A: Spatial footprints (unit_id x height x width).
+        C: Temporal traces (unit_id x frame).
+        S: Deconvolved spikes (unit_id x frame).
+        b: Background spatial component (height x width).
+        f: Background temporal component (frame).
+        b0: Baseline (unit_id x frame).
+        c0: Initial calcium (unit_id x frame).
+        config_out: Merged config for downstream.
+
+    Raises:
+        RuntimeError: If no Dask distributed client is active.
+    """
+```
+
+### Module 4: component_filtering
+
+```python
+def filter_components(
+    A: xr.DataArray,
+    C: xr.DataArray,
+    S: xr.DataArray,
+    b0: xr.DataArray,
+    c0: xr.DataArray,
+    config: dict,
+) -> FilterResult:
+    """
+    Args:
+        A, C, S, b0, c0: CNMF outputs from Module 3.
+        config: Dict with optional param_final_merge, quality thresholds.
+
+    Returns:
+        FilterResult dataclass with fields:
+            A, C, S: Filtered arrays.
+            labels: Per-unit accept (1) / reject (-1) labels.
+            metrics: Per-unit quality metrics dict.
+            config_out: Final config.
+    """
+```
+
+## Required Metadata Handoff
+
+`config_out` from each module is merged into the next module's input config.
+Critical fields that must be threaded through:
+
+- `chk` (chunk sizes) — set by preprocessing, used by all downstream modules
+- `intpath` — intermediate zarr storage path, used by all modules
+- `param_save_minian` — final output save parameters
+- `dpath` — absolute path to data directory
+
+## Enforced Behavior
+
+- **Dask client**: Caller-managed (not module-managed). Each module documents the
+  requirement. `source_detection` raises `RuntimeError` if no active Dask client.
+- **Dask config**: Each module entry point sets the MiniAn Dask optimizations
+  (`custom_arr_optimize`, `custom_delay_optimize`, memory settings) to ensure
+  deterministic graph execution regardless of import order.
+- **MINIAN_INTERMEDIATE**: Each module manages `os.environ["MINIAN_INTERMEDIATE"]`
+  internally. The `intpath` is passed via config.
+- **Intermediate saves**: Each module uses `save_minian()` at the exact same points
+  as the monolithic pipeline to ensure Dask graph materialization matches.
+
+## Example Chaining Pattern
+
+```python
+from preprocessing import preprocess_video
+from motion_correction import correct_motion
+from source_detection import detect_sources
+from component_filtering import filter_components
+
+# Caller manages Dask client
+from dask.distributed import Client, LocalCluster
+cluster = LocalCluster(n_workers=4, memory_limit="2GB",
+                       resources={"MEM": 1}, threads_per_worker=2)
+client = Client(cluster)
+
+Y_bg, chk, cfg_pp = preprocess_video(dpath, config)
+Y_hw, Y_fm, motion, max_proj, cfg_mc = correct_motion(Y_bg, cfg_pp)
+A, C, S, b, f, b0, c0, cfg_sd = detect_sources(Y_hw, Y_fm, max_proj, cfg_mc)
+result = filter_components(A, C, S, b0, c0, cfg_sd)
+
+client.close()
+cluster.close()
+```
+
+## Ground Truth Assertions (from test_pipeline.py)
+
+```python
+assert sizes["frame"] == 2000
+assert sizes["height"] == 480
+assert sizes["width"] == 752
+assert sizes["unit_id"] == 282
+assert motion.sum("frame") == [423, -239]
+assert int(max_proj.sum()) == 1501505
+assert int(C.sum()) == 478444
+assert int(S.sum()) == 3943
+assert int(A.sum()) == 41755
+```

--- a/separation/component_filtering/component_filtering/__init__.py
+++ b/separation/component_filtering/component_filtering/__init__.py
@@ -1,0 +1,6 @@
+"""Component filtering module for MiniAn pipeline separation."""
+from __future__ import annotations
+
+from .filter import FilterResult, filter_components
+
+__all__ = ["FilterResult", "filter_components"]

--- a/separation/component_filtering/component_filtering/defaults.py
+++ b/separation/component_filtering/component_filtering/defaults.py
@@ -1,0 +1,19 @@
+"""Default parameters for the component filtering module.
+
+The original pipeline.ipynb does not have an explicit filtering step;
+update_temporal implicitly drops zero-trace units. This module adds
+an explicit post-processing layer with quality metrics.
+"""
+from __future__ import annotations
+
+
+def get_defaults() -> dict:
+    """Return the default component filtering config."""
+    return {
+        # Optional final merge pass (disabled by default for exact parity)
+        "param_final_merge": None,
+        # Quality thresholds (informational — set to None to accept all)
+        "snr_threshold": None,
+        "spatial_contiguity_threshold": None,
+        "temporal_stability_threshold": None,
+    }

--- a/separation/component_filtering/component_filtering/filter.py
+++ b/separation/component_filtering/component_filtering/filter.py
@@ -1,0 +1,172 @@
+"""Component filtering module entry point.
+
+Provides explicit post-CNMF quality filtering with per-unit metrics.
+For exact parity with the monolithic notebook (which has no explicit
+filtering), the default behavior passes all units through with labels=1.
+"""
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import dask as da
+import numpy as np
+import xarray as xr
+
+from minian.utilities import custom_arr_optimize, custom_delay_optimize
+
+from .defaults import get_defaults
+
+
+@dataclass
+class FilterResult:
+    """Result of component filtering."""
+
+    A: xr.DataArray
+    C: xr.DataArray
+    S: xr.DataArray
+    labels: np.ndarray  # 1=accepted, -1=rejected
+    metrics: Dict[str, np.ndarray]
+    config_out: Dict
+
+
+def _setup_dask_config() -> None:
+    """Replicate Dask config from minian/__init__.py."""
+    da.config.set(
+        array_optimize=custom_arr_optimize,
+        delayed_optimize=custom_delay_optimize,
+    )
+    da.config.set(
+        **{
+            "distributed.worker.memory.target": 0.8,
+            "distributed.worker.memory.spill": 0.85,
+            "distributed.worker.memory.pause": 0.9,
+            "distributed.worker.memory.terminate": 0.95,
+            "distributed.admin.log-length": 100,
+            "distributed.scheduler.transition-log-length": 100,
+            "optimization.fuse.ave-width": 3,
+            "array.slicing.split_large_chunks": False,
+        }
+    )
+    os.environ["MALLOC_MMAP_THRESHOLD_"] = "16384"
+
+
+def _compute_snr(C: np.ndarray) -> np.ndarray:
+    """Compute signal-to-noise ratio per unit from temporal traces."""
+    n_units = C.shape[0]
+    snr = np.zeros(n_units, dtype=np.float64)
+    for i in range(n_units):
+        trace = C[i]
+        signal = np.max(trace) - np.min(trace)
+        noise = np.std(trace)
+        snr[i] = signal / noise if noise > 0 else 0.0
+    return snr
+
+
+def _compute_spatial_contiguity(A: np.ndarray) -> np.ndarray:
+    """Compute spatial contiguity per unit (fraction of non-zero pixels in bounding box)."""
+    n_units = A.shape[0]
+    contiguity = np.zeros(n_units, dtype=np.float64)
+    for i in range(n_units):
+        footprint = A[i]
+        nonzero = footprint > 0
+        if not np.any(nonzero):
+            contiguity[i] = 0.0
+            continue
+        rows = np.any(nonzero, axis=1)
+        cols = np.any(nonzero, axis=0)
+        rmin, rmax = np.where(rows)[0][[0, -1]]
+        cmin, cmax = np.where(cols)[0][[0, -1]]
+        bbox_area = (rmax - rmin + 1) * (cmax - cmin + 1)
+        contiguity[i] = np.sum(nonzero) / bbox_area if bbox_area > 0 else 0.0
+    return contiguity
+
+
+def _compute_temporal_stability(C: np.ndarray) -> np.ndarray:
+    """Compute temporal stability per unit (inverse coefficient of variation)."""
+    n_units = C.shape[0]
+    stability = np.zeros(n_units, dtype=np.float64)
+    for i in range(n_units):
+        trace = C[i]
+        mean_val = np.mean(trace)
+        std_val = np.std(trace)
+        if std_val > 0 and mean_val != 0:
+            stability[i] = abs(mean_val) / std_val
+        else:
+            stability[i] = 0.0
+    return stability
+
+
+def filter_components(
+    A: xr.DataArray,
+    C: xr.DataArray,
+    S: xr.DataArray,
+    b0: xr.DataArray,
+    c0: xr.DataArray,
+    config: dict,
+) -> FilterResult:
+    """Filter CNMF components based on quality metrics.
+
+    For exact parity with the monolithic notebook (which has no explicit
+    filtering), the default behavior passes all units through with labels=1.
+    Quality metrics are computed but only used for filtering when thresholds
+    are set in config.
+
+    Args:
+        A: Spatial footprints from source detection.
+        C: Temporal traces from source detection.
+        S: Deconvolved spikes from source detection.
+        b0: Baseline from source detection.
+        c0: Initial calcium from source detection.
+        config: Configuration dict with optional thresholds.
+
+    Returns:
+        FilterResult with filtered arrays, labels, and metrics.
+    """
+    _setup_dask_config()
+
+    defaults = get_defaults()
+    cfg = deepcopy(defaults)
+    cfg.update(deepcopy(config))
+
+    # Compute arrays for metric calculation
+    A_np = A.values if hasattr(A, "values") else np.asarray(A.compute())
+    C_np = C.values if hasattr(C, "values") else np.asarray(C.compute())
+
+    n_units = A_np.shape[0] if A_np.ndim == 3 else 0
+
+    # Compute quality metrics
+    metrics = {}
+    if n_units > 0:
+        metrics["snr"] = _compute_snr(C_np)
+        metrics["spatial_contiguity"] = _compute_spatial_contiguity(A_np)
+        metrics["temporal_stability"] = _compute_temporal_stability(C_np)
+    else:
+        metrics["snr"] = np.array([], dtype=np.float64)
+        metrics["spatial_contiguity"] = np.array([], dtype=np.float64)
+        metrics["temporal_stability"] = np.array([], dtype=np.float64)
+
+    # Default: accept all units (for exact parity with notebook)
+    labels = np.ones(n_units, dtype=np.int8)
+
+    # Apply thresholds if set
+    if cfg.get("snr_threshold") is not None and n_units > 0:
+        labels[metrics["snr"] < cfg["snr_threshold"]] = -1
+    if cfg.get("spatial_contiguity_threshold") is not None and n_units > 0:
+        labels[metrics["spatial_contiguity"] < cfg["spatial_contiguity_threshold"]] = -1
+    if cfg.get("temporal_stability_threshold") is not None and n_units > 0:
+        labels[metrics["temporal_stability"] < cfg["temporal_stability_threshold"]] = -1
+
+    # Build config_out
+    config_out = deepcopy(cfg)
+
+    return FilterResult(
+        A=A,
+        C=C,
+        S=S,
+        labels=labels,
+        metrics=metrics,
+        config_out=config_out,
+    )

--- a/separation/component_filtering/tests/test_component_filtering_standalone.py
+++ b/separation/component_filtering/tests/test_component_filtering_standalone.py
@@ -1,0 +1,100 @@
+"""Standalone tests for the component filtering module."""
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import xarray as xr
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from component_filtering import FilterResult, filter_components
+
+
+def _make_synthetic_cnmf_outputs(n_units: int = 5, n_frames: int = 100, h: int = 30, w: int = 30):
+    """Create synthetic CNMF output arrays for testing."""
+    rng = np.random.RandomState(42)
+
+    A = xr.DataArray(
+        np.abs(rng.randn(n_units, h, w)).astype(np.float64),
+        dims=["unit_id", "height", "width"],
+        coords={"unit_id": np.arange(n_units), "height": np.arange(h), "width": np.arange(w)},
+    )
+    C = xr.DataArray(
+        np.abs(rng.randn(n_units, n_frames)).astype(np.float64),
+        dims=["unit_id", "frame"],
+        coords={"unit_id": np.arange(n_units), "frame": np.arange(n_frames)},
+    )
+    S = xr.DataArray(
+        np.abs(rng.randn(n_units, n_frames)).astype(np.float64) * 0.1,
+        dims=["unit_id", "frame"],
+        coords={"unit_id": np.arange(n_units), "frame": np.arange(n_frames)},
+    )
+    b0 = xr.DataArray(
+        rng.randn(n_units, n_frames).astype(np.float64) * 0.01,
+        dims=["unit_id", "frame"],
+        coords={"unit_id": np.arange(n_units), "frame": np.arange(n_frames)},
+    )
+    c0 = xr.DataArray(
+        rng.randn(n_units, n_frames).astype(np.float64) * 0.01,
+        dims=["unit_id", "frame"],
+        coords={"unit_id": np.arange(n_units), "frame": np.arange(n_frames)},
+    )
+    return A, C, S, b0, c0
+
+
+def test_filter_components_passthrough():
+    """Test that default config passes all units through."""
+    A, C, S, b0, c0 = _make_synthetic_cnmf_outputs()
+    result = filter_components(A, C, S, b0, c0, {})
+
+    assert isinstance(result, FilterResult)
+    assert len(result.labels) == 5
+    assert np.all(result.labels == 1)
+    assert "snr" in result.metrics
+    assert "spatial_contiguity" in result.metrics
+    assert "temporal_stability" in result.metrics
+    assert result.A is A
+    assert result.C is C
+    assert result.S is S
+
+    print("test_filter_components_passthrough PASSED")
+
+
+def test_filter_components_with_thresholds():
+    """Test filtering with explicit thresholds."""
+    A, C, S, b0, c0 = _make_synthetic_cnmf_outputs()
+    config = {"snr_threshold": 100.0}  # Very high threshold to reject all
+    result = filter_components(A, C, S, b0, c0, config)
+
+    assert isinstance(result, FilterResult)
+    assert np.all(result.labels == -1)
+
+    print("test_filter_components_with_thresholds PASSED")
+
+
+def test_filter_components_empty():
+    """Test filtering with zero units."""
+    A = xr.DataArray(
+        np.empty((0, 10, 10), dtype=np.float64),
+        dims=["unit_id", "height", "width"],
+    )
+    C = xr.DataArray(
+        np.empty((0, 50), dtype=np.float64),
+        dims=["unit_id", "frame"],
+    )
+    S = C.copy()
+    b0 = C.copy()
+    c0 = C.copy()
+    result = filter_components(A, C, S, b0, c0, {})
+
+    assert len(result.labels) == 0
+    assert len(result.metrics["snr"]) == 0
+
+    print("test_filter_components_empty PASSED")
+
+
+if __name__ == "__main__":
+    test_filter_components_passthrough()
+    test_filter_components_with_thresholds()
+    test_filter_components_empty()

--- a/separation/motion_correction/motion_correction/__init__.py
+++ b/separation/motion_correction/motion_correction/__init__.py
@@ -1,0 +1,6 @@
+"""Motion correction module for MiniAn pipeline separation."""
+from __future__ import annotations
+
+from .correct import correct_motion
+
+__all__ = ["correct_motion"]

--- a/separation/motion_correction/motion_correction/correct.py
+++ b/separation/motion_correction/motion_correction/correct.py
@@ -1,0 +1,114 @@
+"""Motion correction module entry point.
+
+Wraps MiniAn estimate_motion and apply_transform to replicate
+the exact motion correction steps from pipeline.ipynb.
+"""
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from typing import Dict, Tuple
+
+import dask as da
+import xarray as xr
+
+from minian.motion_correction import apply_transform, estimate_motion
+from minian.utilities import (
+    custom_arr_optimize,
+    custom_delay_optimize,
+    save_minian,
+)
+
+from .defaults import get_defaults
+
+
+def _setup_dask_config() -> None:
+    """Replicate Dask config from minian/__init__.py."""
+    da.config.set(
+        array_optimize=custom_arr_optimize,
+        delayed_optimize=custom_delay_optimize,
+    )
+    da.config.set(
+        **{
+            "distributed.worker.memory.target": 0.8,
+            "distributed.worker.memory.spill": 0.85,
+            "distributed.worker.memory.pause": 0.9,
+            "distributed.worker.memory.terminate": 0.95,
+            "distributed.admin.log-length": 100,
+            "distributed.scheduler.transition-log-length": 100,
+            "optimization.fuse.ave-width": 3,
+            "array.slicing.split_large_chunks": False,
+        }
+    )
+    os.environ["MALLOC_MMAP_THRESHOLD_"] = "16384"
+
+
+def correct_motion(
+    Y_bg: xr.DataArray,
+    config: dict,
+) -> Tuple[xr.DataArray, xr.DataArray, xr.DataArray, xr.DataArray, Dict]:
+    """Run motion correction: estimate motion, apply transform, rechunk.
+
+    Args:
+        Y_bg: Preprocessed video from preprocessing module.
+        config: Configuration dict. Must include 'chk', 'intpath'.
+                Optional: param_estimate_motion, subset_mc, param_save_minian.
+
+    Returns:
+        Y_hw_chk: Motion-corrected video, spatial-chunked.
+        Y_fm_chk: Motion-corrected video, frame-chunked.
+        motion: Estimated motion shifts.
+        max_proj: Maximum projection of corrected video.
+        config_out: Merged config for downstream modules.
+    """
+    _setup_dask_config()
+
+    defaults = get_defaults()
+    cfg = deepcopy(defaults)
+    cfg.update(deepcopy(config))
+
+    chk = cfg["chk"]
+    intpath = cfg["intpath"]
+    subset_mc = cfg.get("subset_mc", None)
+    param_save_minian = cfg.get("param_save_minian", {
+        "dpath": os.path.join(cfg.get("dpath", "."), "minian"),
+        "meta_dict": dict(session=-1, animal=-2),
+        "overwrite": True,
+    })
+
+    os.environ["MINIAN_INTERMEDIATE"] = intpath
+
+    # Step 1: Estimate motion
+    varr_sel = Y_bg.sel(subset_mc) if subset_mc is not None else Y_bg
+    motion = estimate_motion(varr_sel, **cfg["param_estimate_motion"])
+
+    # Step 2: Save motion to final output
+    motion = save_minian(
+        motion.rename("motion").chunk({"frame": chk["frame"]}),
+        **param_save_minian,
+    )
+
+    # Step 3: Apply transform
+    Y = apply_transform(Y_bg, motion, fill=0)
+
+    # Step 4: Save frame-chunked and spatial-chunked versions
+    Y_fm_chk = save_minian(
+        Y.astype(float).rename("Y_fm_chk"), intpath, overwrite=True
+    )
+    Y_hw_chk = save_minian(
+        Y_fm_chk.rename("Y_hw_chk"),
+        intpath,
+        overwrite=True,
+        chunks={"frame": -1, "height": chk["height"], "width": chk["width"]},
+    )
+
+    # Step 5: Compute and save max projection
+    max_proj = save_minian(
+        Y_fm_chk.max("frame").rename("max_proj"), **param_save_minian
+    ).compute()
+
+    # Build config_out for downstream
+    config_out = deepcopy(cfg)
+    config_out["param_save_minian"] = param_save_minian
+
+    return Y_hw_chk, Y_fm_chk, motion, max_proj, config_out

--- a/separation/motion_correction/motion_correction/defaults.py
+++ b/separation/motion_correction/motion_correction/defaults.py
@@ -1,0 +1,13 @@
+"""Default parameters for the motion correction module.
+
+Extracted from pipeline.ipynb parameter cells.
+"""
+from __future__ import annotations
+
+
+def get_defaults() -> dict:
+    """Return the default motion correction config matching pipeline.ipynb."""
+    return {
+        "param_estimate_motion": {"dim": "frame"},
+        "subset_mc": None,
+    }

--- a/separation/motion_correction/tests/test_motion_correction_standalone.py
+++ b/separation/motion_correction/tests/test_motion_correction_standalone.py
@@ -1,0 +1,79 @@
+"""Standalone tests for the motion correction module."""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+
+import numpy as np
+import pytest
+import xarray as xr
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from motion_correction import correct_motion
+
+
+def _make_synthetic_video(n_frames: int = 50, h: int = 32, w: int = 32) -> xr.DataArray:
+    """Create a synthetic preprocessed video DataArray."""
+    rng = np.random.RandomState(42)
+    data = rng.rand(n_frames, h, w).astype(np.float64)
+    return xr.DataArray(
+        data,
+        dims=["frame", "height", "width"],
+        coords={
+            "frame": np.arange(n_frames),
+            "height": np.arange(h),
+            "width": np.arange(w),
+        },
+    )
+
+
+def test_correct_motion_output_types():
+    """Verify correct_motion returns correct types and shapes."""
+    tmpdir = tempfile.mkdtemp(prefix="minian_test_mc_")
+    intpath = os.path.join(tmpdir, "intermediate")
+    dpath = os.path.join(tmpdir, "data")
+    minian_path = os.path.join(dpath, "minian")
+    os.makedirs(minian_path, exist_ok=True)
+
+    try:
+        Y_bg = _make_synthetic_video()
+        config = {
+            "param_estimate_motion": {"dim": "frame"},
+            "subset_mc": None,
+            "chk": {"frame": 25, "height": 16, "width": 16},
+            "intpath": intpath,
+            "dpath": dpath,
+            "param_save_minian": {
+                "dpath": minian_path,
+                "meta_dict": dict(session=-1, animal=-2),
+                "overwrite": True,
+            },
+        }
+
+        Y_hw_chk, Y_fm_chk, motion, max_proj, config_out = correct_motion(
+            Y_bg, config
+        )
+
+        # Type checks
+        assert isinstance(Y_hw_chk, xr.DataArray)
+        assert isinstance(Y_fm_chk, xr.DataArray)
+        assert isinstance(motion, xr.DataArray)
+        assert isinstance(max_proj, xr.DataArray)
+        assert isinstance(config_out, dict)
+
+        # Shape checks
+        assert set(Y_hw_chk.dims) == {"frame", "height", "width"}
+        assert set(Y_fm_chk.dims) == {"frame", "height", "width"}
+        assert "frame" in motion.dims
+        assert set(max_proj.dims) == {"height", "width"}
+
+        print("test_correct_motion_output_types PASSED")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    test_correct_motion_output_types()

--- a/separation/preprocessing/preprocessing/__init__.py
+++ b/separation/preprocessing/preprocessing/__init__.py
@@ -1,0 +1,6 @@
+"""Preprocessing module for MiniAn pipeline separation."""
+from __future__ import annotations
+
+from .preprocess import preprocess_video
+
+__all__ = ["preprocess_video"]

--- a/separation/preprocessing/preprocessing/defaults.py
+++ b/separation/preprocessing/preprocessing/defaults.py
@@ -1,0 +1,23 @@
+"""Default parameters for the preprocessing module.
+
+Extracted from pipeline.ipynb parameter cells.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def get_defaults() -> dict:
+    """Return the default preprocessing config matching pipeline.ipynb."""
+    return {
+        "param_load_videos": {
+            "pattern": r"msCam[0-9]+\.avi$",
+            "dtype": np.uint8,
+            "downsample": dict(frame=1, height=1, width=1),
+            "downsample_strategy": "subset",
+        },
+        "param_denoise": {"method": "median", "ksize": 7},
+        "param_background_removal": {"method": "tophat", "wnd": 15},
+        "subset": dict(frame=slice(0, None)),
+        "intpath": "./minian_intermediate",
+    }

--- a/separation/preprocessing/preprocessing/preprocess.py
+++ b/separation/preprocessing/preprocessing/preprocess.py
@@ -1,0 +1,111 @@
+"""Preprocessing module entry point.
+
+Wraps MiniAn load_videos, denoise, and remove_background to replicate
+the exact preprocessing steps from pipeline.ipynb.
+"""
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from typing import Dict, Tuple
+
+import dask as da
+import xarray as xr
+
+from minian.preprocessing import denoise, remove_background
+from minian.utilities import (
+    custom_arr_optimize,
+    custom_delay_optimize,
+    get_optimal_chk,
+    load_videos,
+    save_minian,
+)
+
+from .defaults import get_defaults
+
+
+def _setup_dask_config() -> None:
+    """Replicate Dask config from minian/__init__.py."""
+    da.config.set(
+        array_optimize=custom_arr_optimize,
+        delayed_optimize=custom_delay_optimize,
+    )
+    da.config.set(
+        **{
+            "distributed.worker.memory.target": 0.8,
+            "distributed.worker.memory.spill": 0.85,
+            "distributed.worker.memory.pause": 0.9,
+            "distributed.worker.memory.terminate": 0.95,
+            "distributed.admin.log-length": 100,
+            "distributed.scheduler.transition-log-length": 100,
+            "optimization.fuse.ave-width": 3,
+            "array.slicing.split_large_chunks": False,
+        }
+    )
+    os.environ["MALLOC_MMAP_THRESHOLD_"] = "16384"
+
+
+def preprocess_video(
+    dpath: str,
+    config: dict,
+) -> Tuple[xr.DataArray, Dict, Dict]:
+    """Run preprocessing: load, glow removal, denoise, background removal.
+
+    Args:
+        dpath: Path to directory containing raw video files.
+        config: Configuration dict. Missing keys are filled from defaults.
+
+    Returns:
+        Y_bg: Background-removed video (xr.DataArray).
+        chk: Chunk size dict with keys 'frame', 'height', 'width'.
+        config_out: Merged config including chk, intpath, dpath.
+    """
+    _setup_dask_config()
+
+    defaults = get_defaults()
+    cfg = deepcopy(defaults)
+    cfg.update(deepcopy(config))
+
+    intpath = cfg["intpath"]
+    subset = cfg.get("subset", dict(frame=slice(0, None)))
+
+    os.environ["MINIAN_INTERMEDIATE"] = intpath
+
+    # Step 1: Load videos
+    dpath = os.path.abspath(dpath)
+    varr = load_videos(dpath, **cfg["param_load_videos"])
+
+    # Step 2: Get optimal chunk sizes
+    chk, _ = get_optimal_chk(varr, dtype=float)
+
+    # Step 3: Chunk and save raw video to intermediate
+    varr = save_minian(
+        varr.chunk({"frame": chk["frame"], "height": -1, "width": -1}).rename("varr"),
+        intpath,
+        overwrite=True,
+    )
+
+    # Step 4: Apply subset selection
+    varr_ref = varr.sel(subset)
+
+    # Step 5: Glow removal (subtract per-pixel minimum)
+    varr_min = varr_ref.min("frame").compute()
+    varr_ref = varr_ref - varr_min
+
+    # Step 6: Denoise
+    varr_ref = denoise(varr_ref, **cfg["param_denoise"])
+
+    # Step 7: Background removal
+    varr_ref = remove_background(varr_ref, **cfg["param_background_removal"])
+
+    # Step 8: Save preprocessed video to intermediate
+    varr_ref = save_minian(
+        varr_ref.rename("varr_ref"), dpath=intpath, overwrite=True
+    )
+
+    # Build config_out for downstream modules
+    config_out = deepcopy(cfg)
+    config_out["chk"] = chk
+    config_out["dpath"] = dpath
+
+    return varr_ref, chk, config_out

--- a/separation/preprocessing/tests/test_preprocessing_standalone.py
+++ b/separation/preprocessing/tests/test_preprocessing_standalone.py
@@ -1,0 +1,83 @@
+"""Standalone tests for the preprocessing module."""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+
+import numpy as np
+import pytest
+import xarray as xr
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from preprocessing import preprocess_video
+
+
+def _make_temp_videos(tmpdir: str, n_frames: int = 30, h: int = 32, w: int = 32) -> str:
+    """Create a minimal AVI video file for testing."""
+    try:
+        import cv2
+    except ImportError:
+        pytest.skip("cv2 not available for creating test videos")
+
+    vpath = os.path.join(tmpdir, "msCam1.avi")
+    fourcc = cv2.VideoWriter_fourcc(*"XVID")
+    out = cv2.VideoWriter(vpath, fourcc, 30.0, (w, h), isColor=False)
+    rng = np.random.RandomState(42)
+    for _ in range(n_frames):
+        frame = rng.randint(0, 256, (h, w), dtype=np.uint8)
+        out.write(frame)
+    out.release()
+    return tmpdir
+
+
+def test_preprocess_video_output_types():
+    """Verify preprocess_video returns correct types and shapes."""
+    tmpdir = tempfile.mkdtemp(prefix="minian_test_pp_")
+    intpath = os.path.join(tmpdir, "intermediate")
+
+    try:
+        dpath = _make_temp_videos(tmpdir)
+        config = {
+            "param_load_videos": {
+                "pattern": r"msCam[0-9]+\.avi$",
+                "dtype": np.uint8,
+                "downsample": dict(frame=1, height=1, width=1),
+                "downsample_strategy": "subset",
+            },
+            "param_denoise": {"method": "median", "ksize": 7},
+            "param_background_removal": {"method": "tophat", "wnd": 15},
+            "intpath": intpath,
+            "subset": dict(frame=slice(0, None)),
+        }
+
+        Y_bg, chk, config_out = preprocess_video(dpath, config)
+
+        # Type checks
+        assert isinstance(Y_bg, xr.DataArray)
+        assert isinstance(chk, dict)
+        assert isinstance(config_out, dict)
+
+        # Shape checks
+        assert "frame" in Y_bg.dims
+        assert "height" in Y_bg.dims
+        assert "width" in Y_bg.dims
+
+        # Chunk dict
+        assert "frame" in chk
+        assert "height" in chk
+        assert "width" in chk
+
+        # config_out must include chk and dpath
+        assert "chk" in config_out
+        assert "dpath" in config_out
+
+        print("test_preprocess_video_output_types PASSED")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    test_preprocess_video_output_types()

--- a/separation/source_detection/source_detection/__init__.py
+++ b/separation/source_detection/source_detection/__init__.py
@@ -1,0 +1,6 @@
+"""Source detection module for MiniAn pipeline separation."""
+from __future__ import annotations
+
+from .detect import detect_sources
+
+__all__ = ["detect_sources"]

--- a/separation/source_detection/source_detection/defaults.py
+++ b/separation/source_detection/source_detection/defaults.py
@@ -1,0 +1,55 @@
+"""Default parameters for the source detection (CNMF) module.
+
+Extracted from pipeline.ipynb parameter cells.
+"""
+from __future__ import annotations
+
+
+def get_defaults() -> dict:
+    """Return the default source detection config matching pipeline.ipynb."""
+    return {
+        # Initialization parameters
+        "param_seeds_init": {
+            "wnd_size": 1000,
+            "method": "rolling",
+            "stp_size": 500,
+            "max_wnd": 15,
+            "diff_thres": 3,
+        },
+        "param_pnr_refine": {"noise_freq": 0.06, "thres": 1},
+        "param_ks_refine": {"sig": 0.05},
+        "param_seeds_merge": {
+            "thres_dist": 10,
+            "thres_corr": 0.8,
+            "noise_freq": 0.06,
+        },
+        "param_initialize": {"thres_corr": 0.8, "wnd": 10, "noise_freq": 0.06},
+        "param_init_merge": {"thres_corr": 0.8},
+        # CNMF parameters
+        "param_get_noise": {"noise_range": (0.06, 0.5)},
+        "param_first_spatial": {
+            "dl_wnd": 10,
+            "sparse_penal": 0.01,
+            "size_thres": (25, None),
+        },
+        "param_first_temporal": {
+            "noise_freq": 0.06,
+            "sparse_penal": 1,
+            "p": 1,
+            "add_lag": 20,
+            "jac_thres": 0.2,
+        },
+        "param_first_merge": {"thres_corr": 0.8},
+        "param_second_spatial": {
+            "dl_wnd": 10,
+            "sparse_penal": 0.01,
+            "size_thres": (25, None),
+        },
+        "param_second_temporal": {
+            "noise_freq": 0.06,
+            "sparse_penal": 1,
+            "p": 1,
+            "add_lag": 20,
+            "jac_thres": 0.4,
+        },
+    }

--- a/separation/source_detection/source_detection/detect.py
+++ b/separation/source_detection/source_detection/detect.py
@@ -1,0 +1,365 @@
+"""Source detection module entry point.
+
+Wraps the full MiniAn CNMF pipeline: seed initialization, component
+initialization, noise estimation, two rounds of spatial/temporal updates
+with merging — replicating the exact sequence from pipeline.ipynb.
+"""
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from typing import Dict, Tuple
+
+import dask as da
+import xarray as xr
+
+from minian.cnmf import (
+    compute_trace,
+    get_noise_fft,
+    unit_merge,
+    update_background,
+    update_spatial,
+    update_temporal,
+)
+from minian.initialization import (
+    initA,
+    initC,
+    ks_refine,
+    pnr_refine,
+    seeds_init,
+    seeds_merge,
+)
+from minian.utilities import (
+    custom_arr_optimize,
+    custom_delay_optimize,
+    save_minian,
+)
+
+from .defaults import get_defaults
+
+
+def _setup_dask_config() -> None:
+    """Replicate Dask config from minian/__init__.py."""
+    da.config.set(
+        array_optimize=custom_arr_optimize,
+        delayed_optimize=custom_delay_optimize,
+    )
+    da.config.set(
+        **{
+            "distributed.worker.memory.target": 0.8,
+            "distributed.worker.memory.spill": 0.85,
+            "distributed.worker.memory.pause": 0.9,
+            "distributed.worker.memory.terminate": 0.95,
+            "distributed.admin.log-length": 100,
+            "distributed.scheduler.transition-log-length": 100,
+            "optimization.fuse.ave-width": 3,
+            "array.slicing.split_large_chunks": False,
+        }
+    )
+    os.environ["MALLOC_MMAP_THRESHOLD_"] = "16384"
+
+
+def _check_dask_client() -> None:
+    """Raise RuntimeError if no active Dask distributed client."""
+    try:
+        from dask.distributed import get_client
+        get_client()
+    except (ImportError, ValueError):
+        raise RuntimeError(
+            "source_detection requires an active Dask distributed client. "
+            "Create one with: client = Client(LocalCluster(...))"
+        )
+
+
+def detect_sources(
+    Y_hw_chk: xr.DataArray,
+    Y_fm_chk: xr.DataArray,
+    max_proj: xr.DataArray,
+    config: dict,
+) -> Tuple[xr.DataArray, xr.DataArray, xr.DataArray, xr.DataArray,
+           xr.DataArray, xr.DataArray, xr.DataArray, Dict]:
+    """Run full CNMF source detection pipeline.
+
+    Args:
+        Y_hw_chk: Spatial-chunked motion-corrected video.
+        Y_fm_chk: Frame-chunked motion-corrected video.
+        max_proj: Maximum projection of corrected video.
+        config: Configuration dict with all CNMF parameters, chk, intpath,
+                param_save_minian.
+
+    Returns:
+        A: Spatial footprints.
+        C: Temporal traces.
+        S: Deconvolved spikes.
+        b: Background spatial component.
+        f: Background temporal component.
+        b0: Baseline.
+        c0: Initial calcium.
+        config_out: Merged config for downstream.
+
+    Raises:
+        RuntimeError: If no active Dask distributed client.
+    """
+    _setup_dask_config()
+    _check_dask_client()
+
+    defaults = get_defaults()
+    cfg = deepcopy(defaults)
+    cfg.update(deepcopy(config))
+
+    chk = cfg["chk"]
+    intpath = cfg["intpath"]
+    param_save_minian = cfg.get("param_save_minian", {
+        "dpath": os.path.join(cfg.get("dpath", "."), "minian"),
+        "meta_dict": dict(session=-1, animal=-2),
+        "overwrite": True,
+    })
+
+    os.environ["MINIAN_INTERMEDIATE"] = intpath
+
+    # ================================================================
+    # SEED INITIALIZATION
+    # ================================================================
+
+    # Step 1: Initial seed detection
+    seeds = seeds_init(Y_fm_chk, **cfg["param_seeds_init"])
+
+    # Step 2: PNR refinement
+    seeds, pnr, gmm = pnr_refine(Y_hw_chk, seeds, **cfg["param_pnr_refine"])
+
+    # Step 3: KS refinement
+    seeds = ks_refine(Y_hw_chk, seeds, **cfg["param_ks_refine"])
+
+    # Step 4: Filter and merge seeds
+    seeds_final = seeds[seeds["mask_ks"] & seeds["mask_pnr"]].reset_index(drop=True)
+    seeds_final = seeds_merge(Y_hw_chk, max_proj, seeds_final, **cfg["param_seeds_merge"])
+
+    # ================================================================
+    # COMPONENT INITIALIZATION
+    # ================================================================
+
+    # Step 5: Initialize spatial components
+    A_init = initA(
+        Y_hw_chk, seeds_final[seeds_final["mask_mrg"]], **cfg["param_initialize"]
+    )
+    A_init = save_minian(A_init.rename("A_init"), intpath, overwrite=True)
+
+    # Step 6: Initialize temporal components
+    C_init = initC(Y_fm_chk, A_init)
+    C_init = save_minian(
+        C_init.rename("C_init"),
+        intpath,
+        overwrite=True,
+        chunks={"unit_id": 1, "frame": -1},
+    )
+
+    # Step 7: Initial merge
+    A, C = unit_merge(A_init, C_init, **cfg["param_init_merge"])
+    A = save_minian(A.rename("A"), intpath, overwrite=True)
+    C = save_minian(C.rename("C"), intpath, overwrite=True)
+    C_chk = save_minian(
+        C.rename("C_chk"),
+        intpath,
+        overwrite=True,
+        chunks={"unit_id": -1, "frame": chk["frame"]},
+    )
+
+    # ================================================================
+    # INITIAL BACKGROUND
+    # ================================================================
+
+    # Step 8: Initial background estimation
+    b, f = update_background(Y_fm_chk, A, C_chk)
+    f = save_minian(f.rename("f"), intpath, overwrite=True)
+    b = save_minian(b.rename("b"), intpath, overwrite=True)
+
+    # ================================================================
+    # NOISE ESTIMATION
+    # ================================================================
+
+    # Step 9: Noise estimation
+    sn_spatial = get_noise_fft(Y_hw_chk, **cfg["param_get_noise"])
+    sn_spatial = save_minian(sn_spatial.rename("sn_spatial"), intpath, overwrite=True)
+
+    # ================================================================
+    # FIRST SPATIAL UPDATE
+    # ================================================================
+
+    # Step 10: First spatial update
+    A_new, mask, norm_fac = update_spatial(
+        Y_hw_chk, A, C, sn_spatial, **cfg["param_first_spatial"]
+    )
+    C_new = save_minian(
+        (C.sel(unit_id=mask) * norm_fac).rename("C_new"), intpath, overwrite=True
+    )
+    C_chk_new = save_minian(
+        (C_chk.sel(unit_id=mask) * norm_fac).rename("C_chk_new"),
+        intpath,
+        overwrite=True,
+    )
+
+    # Step 11: First background update
+    b_new, f_new = update_background(Y_fm_chk, A_new, C_chk_new)
+
+    # Step 12: Save first spatial/background update results
+    A = save_minian(
+        A_new.rename("A"),
+        intpath,
+        overwrite=True,
+        chunks={"unit_id": 1, "height": -1, "width": -1},
+    )
+    b = save_minian(b_new.rename("b"), intpath, overwrite=True)
+    f = save_minian(
+        f_new.chunk({"frame": chk["frame"]}).rename("f"), intpath, overwrite=True
+    )
+    C = save_minian(C_new.rename("C"), intpath, overwrite=True)
+    C_chk = save_minian(C_chk_new.rename("C_chk"), intpath, overwrite=True)
+
+    # ================================================================
+    # FIRST TEMPORAL UPDATE
+    # ================================================================
+
+    # Step 13: Compute trace for temporal update
+    YrA = save_minian(
+        compute_trace(Y_fm_chk, A, b, C_chk, f).rename("YrA"),
+        intpath,
+        overwrite=True,
+        chunks={"unit_id": 1, "frame": -1},
+    )
+
+    # Step 14: First temporal update
+    C_new, S_new, b0_new, c0_new, g, mask = update_temporal(
+        A, C, YrA=YrA, **cfg["param_first_temporal"]
+    )
+
+    # Step 15: Save first temporal update results
+    C = save_minian(
+        C_new.rename("C").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True
+    )
+    C_chk = save_minian(
+        C.rename("C_chk"),
+        intpath,
+        overwrite=True,
+        chunks={"unit_id": -1, "frame": chk["frame"]},
+    )
+    S = save_minian(
+        S_new.rename("S").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True
+    )
+    b0 = save_minian(
+        b0_new.rename("b0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True
+    )
+    c0 = save_minian(
+        c0_new.rename("c0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True
+    )
+    A = A.sel(unit_id=C.coords["unit_id"].values)
+
+    # ================================================================
+    # FIRST MERGE
+    # ================================================================
+
+    # Step 16: First merge
+    A_mrg, C_mrg, [sig_mrg] = unit_merge(
+        A, C, [C + b0 + c0], **cfg["param_first_merge"]
+    )
+
+    # Step 17: Save merge results
+    A = save_minian(A_mrg.rename("A_mrg"), intpath, overwrite=True)
+    C = save_minian(C_mrg.rename("C_mrg"), intpath, overwrite=True)
+    C_chk = save_minian(
+        C.rename("C_mrg_chk"),
+        intpath,
+        overwrite=True,
+        chunks={"unit_id": -1, "frame": chk["frame"]},
+    )
+    sig = save_minian(sig_mrg.rename("sig_mrg"), intpath, overwrite=True)
+
+    # ================================================================
+    # SECOND SPATIAL UPDATE
+    # ================================================================
+
+    # Step 18: Second spatial update
+    A_new, mask, norm_fac = update_spatial(
+        Y_hw_chk, A, C, sn_spatial, **cfg["param_second_spatial"]
+    )
+    C_new = save_minian(
+        (C.sel(unit_id=mask) * norm_fac).rename("C_new"), intpath, overwrite=True
+    )
+    C_chk_new = save_minian(
+        (C_chk.sel(unit_id=mask) * norm_fac).rename("C_chk_new"),
+        intpath,
+        overwrite=True,
+    )
+
+    # Step 19: Second background update
+    b_new, f_new = update_background(Y_fm_chk, A_new, C_chk_new)
+
+    # Step 20: Save second spatial/background update results
+    A = save_minian(
+        A_new.rename("A"),
+        intpath,
+        overwrite=True,
+        chunks={"unit_id": 1, "height": -1, "width": -1},
+    )
+    b = save_minian(b_new.rename("b"), intpath, overwrite=True)
+    f = save_minian(
+        f_new.chunk({"frame": chk["frame"]}).rename("f"), intpath, overwrite=True
+    )
+    C = save_minian(C_new.rename("C"), intpath, overwrite=True)
+    C_chk = save_minian(C_chk_new.rename("C_chk"), intpath, overwrite=True)
+
+    # ================================================================
+    # SECOND TEMPORAL UPDATE
+    # ================================================================
+
+    # Step 21: Compute trace for second temporal update
+    YrA = save_minian(
+        compute_trace(Y_fm_chk, A, b, C_chk, f).rename("YrA"),
+        intpath,
+        overwrite=True,
+        chunks={"unit_id": 1, "frame": -1},
+    )
+
+    # Step 22: Second temporal update
+    C_new, S_new, b0_new, c0_new, g, mask = update_temporal(
+        A, C, YrA=YrA, **cfg["param_second_temporal"]
+    )
+
+    # Step 23: Save final temporal update results
+    C = save_minian(
+        C_new.rename("C").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True
+    )
+    C_chk = save_minian(
+        C.rename("C_chk"),
+        intpath,
+        overwrite=True,
+        chunks={"unit_id": -1, "frame": chk["frame"]},
+    )
+    S = save_minian(
+        S_new.rename("S").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True
+    )
+    b0 = save_minian(
+        b0_new.rename("b0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True
+    )
+    c0 = save_minian(
+        c0_new.rename("c0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True
+    )
+    A = A.sel(unit_id=C.coords["unit_id"].values)
+
+    # ================================================================
+    # SAVE FINAL OUTPUTS
+    # ================================================================
+
+    # Step 24: Save final results to minian output directory
+    A = save_minian(A.rename("A"), **param_save_minian)
+    C = save_minian(C.rename("C"), **param_save_minian)
+    S = save_minian(S.rename("S"), **param_save_minian)
+    c0 = save_minian(c0.rename("c0"), **param_save_minian)
+    b0 = save_minian(b0.rename("b0"), **param_save_minian)
+    b = save_minian(b.rename("b"), **param_save_minian)
+    f = save_minian(f.rename("f"), **param_save_minian)
+
+    # Build config_out
+    config_out = deepcopy(cfg)
+    config_out["param_save_minian"] = param_save_minian
+
+    return A, C, S, b, f, b0, c0, config_out

--- a/separation/source_detection/tests/test_source_detection_standalone.py
+++ b/separation/source_detection/tests/test_source_detection_standalone.py
@@ -1,0 +1,129 @@
+"""Standalone tests for the source detection module."""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+
+import numpy as np
+import pytest
+import xarray as xr
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _make_synthetic_movie(
+    n_frames: int = 200, h: int = 50, w: int = 50, n_cells: int = 3
+) -> xr.DataArray:
+    """Create a synthetic movie with bright spots for source detection."""
+    rng = np.random.RandomState(42)
+    data = 0.01 * rng.rand(n_frames, h, w).astype(np.float64)
+
+    # Add synthetic cells
+    for i in range(n_cells):
+        cy = 10 + i * 15
+        cx = 10 + i * 15
+        if cy >= h or cx >= w:
+            continue
+        for dy in range(-4, 5):
+            for dx in range(-4, 5):
+                yy, xx = cy + dy, cx + dx
+                if 0 <= yy < h and 0 <= xx < w:
+                    r2 = dy**2 + dx**2
+                    signal = np.exp(-r2 / 8.0)
+                    temporal = 1 + 0.5 * np.sin(
+                        np.linspace(0, 4 * np.pi * (i + 1), n_frames)
+                    )
+                    data[:, yy, xx] += 0.5 * signal * temporal
+
+    return xr.DataArray(
+        data,
+        dims=["frame", "height", "width"],
+        coords={
+            "frame": np.arange(n_frames),
+            "height": np.arange(h),
+            "width": np.arange(w),
+        },
+    )
+
+
+def test_detect_sources_requires_dask_client():
+    """Verify detect_sources raises RuntimeError without Dask client."""
+    from source_detection import detect_sources
+
+    movie = _make_synthetic_movie(n_frames=10, h=20, w=20)
+    max_proj = movie.max("frame").compute()
+
+    with pytest.raises(RuntimeError, match="Dask distributed client"):
+        detect_sources(movie, movie, max_proj, {
+            "chk": {"frame": 5, "height": 10, "width": 10},
+            "intpath": "/tmp/test_sd",
+        })
+
+
+def test_detect_sources_output_types():
+    """Verify detect_sources returns correct types (requires Dask)."""
+    pytest.importorskip("dask.distributed")
+    from dask.distributed import Client, LocalCluster
+
+    from source_detection import detect_sources
+
+    tmpdir = tempfile.mkdtemp(prefix="minian_test_sd_")
+    intpath = os.path.join(tmpdir, "intermediate")
+    minian_path = os.path.join(tmpdir, "minian")
+    os.makedirs(minian_path, exist_ok=True)
+
+    cluster = LocalCluster(
+        n_workers=2,
+        memory_limit="1GB",
+        threads_per_worker=1,
+    )
+    client = Client(cluster)
+
+    try:
+        movie = _make_synthetic_movie()
+        chk = {"frame": 100, "height": 25, "width": 25}
+
+        Y_fm_chk = movie.chunk({"frame": chk["frame"], "height": -1, "width": -1})
+        Y_hw_chk = movie.chunk({"frame": -1, "height": chk["height"], "width": chk["width"]})
+        max_proj = movie.max("frame").compute()
+
+        config = {
+            "chk": chk,
+            "intpath": intpath,
+            "param_save_minian": {
+                "dpath": minian_path,
+                "meta_dict": dict(session=-1, animal=-2),
+                "overwrite": True,
+            },
+        }
+
+        A, C, S, b, f, b0, c0, config_out = detect_sources(
+            Y_hw_chk, Y_fm_chk, max_proj, config
+        )
+
+        assert isinstance(A, xr.DataArray)
+        assert isinstance(C, xr.DataArray)
+        assert isinstance(S, xr.DataArray)
+        assert isinstance(b, xr.DataArray)
+        assert isinstance(f, xr.DataArray)
+        assert isinstance(b0, xr.DataArray)
+        assert isinstance(c0, xr.DataArray)
+        assert isinstance(config_out, dict)
+
+        assert "unit_id" in A.dims
+        assert "unit_id" in C.dims
+        assert "frame" in C.dims
+
+        print(f"Detected {A.sizes['unit_id']} units")
+        print("test_detect_sources_output_types PASSED")
+
+    finally:
+        client.close()
+        cluster.close()
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    test_detect_sources_output_types()

--- a/separation/test_cross_module_chaining.py
+++ b/separation/test_cross_module_chaining.py
@@ -1,0 +1,459 @@
+"""Cross-module chaining test: preprocessing -> motion_correction -> source_detection -> component_filtering.
+
+Validates that the four standalone packages can be chained together
+to form the complete MiniAn CNMF pipeline, and that running them
+produces the same results as the monolithic inline sequence.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+from copy import deepcopy
+
+import numpy as np
+import pytest
+import xarray as xr
+
+# Add module paths
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "preprocessing"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "motion_correction"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "source_detection"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "component_filtering"))
+
+from component_filtering import FilterResult, filter_components
+from motion_correction import correct_motion
+from preprocessing import preprocess_video
+from source_detection import detect_sources
+
+
+def _make_temp_videos(
+    tmpdir: str, n_frames: int = 100, h: int = 50, w: int = 50, n_cells: int = 3
+) -> str:
+    """Create minimal AVI video files with synthetic cell signals."""
+    try:
+        import cv2
+    except ImportError:
+        pytest.skip("cv2 not available for creating test videos")
+
+    rng = np.random.RandomState(42)
+    vpath = os.path.join(tmpdir, "msCam1.avi")
+    fourcc = cv2.VideoWriter_fourcc(*"XVID")
+    out = cv2.VideoWriter(vpath, fourcc, 30.0, (w, h), isColor=False)
+
+    for t in range(n_frames):
+        frame = (10 + 5 * rng.rand(h, w)).astype(np.uint8)
+        # Add cell signals
+        for i in range(n_cells):
+            cy = 10 + i * 15
+            cx = 10 + i * 15
+            if cy >= h or cx >= w:
+                continue
+            signal = 50 * (1 + 0.5 * np.sin(2 * np.pi * t / 30 * (i + 1)))
+            for dy in range(-3, 4):
+                for dx in range(-3, 4):
+                    yy, xx = cy + dy, cx + dx
+                    if 0 <= yy < h and 0 <= xx < w:
+                        r2 = dy**2 + dx**2
+                        frame[yy, xx] = min(
+                            255, int(frame[yy, xx] + signal * np.exp(-r2 / 4))
+                        )
+        out.write(frame)
+    out.release()
+    return tmpdir
+
+
+def _run_monolithic(dpath, intpath, minian_path, chk_override=None):
+    """Run the pipeline inline (monolithic) for comparison."""
+    from minian.cnmf import (
+        compute_trace,
+        get_noise_fft,
+        unit_merge,
+        update_background,
+        update_spatial,
+        update_temporal,
+    )
+    from minian.initialization import (
+        initA,
+        initC,
+        ks_refine,
+        pnr_refine,
+        seeds_init,
+        seeds_merge,
+    )
+    from minian.motion_correction import apply_transform, estimate_motion
+    from minian.preprocessing import denoise, remove_background
+    from minian.utilities import get_optimal_chk, load_videos, save_minian
+
+    os.environ["MINIAN_INTERMEDIATE"] = intpath
+
+    param_load_videos = {
+        "pattern": r"msCam[0-9]+\.avi$",
+        "dtype": np.uint8,
+        "downsample": dict(frame=1, height=1, width=1),
+        "downsample_strategy": "subset",
+    }
+    param_denoise = {"method": "median", "ksize": 7}
+    param_background_removal = {"method": "tophat", "wnd": 15}
+    param_estimate_motion = {"dim": "frame"}
+    param_save_minian = {
+        "dpath": minian_path,
+        "meta_dict": dict(session=-1, animal=-2),
+        "overwrite": True,
+    }
+    param_seeds_init = {
+        "wnd_size": 1000, "method": "rolling", "stp_size": 500,
+        "max_wnd": 15, "diff_thres": 3,
+    }
+    param_pnr_refine = {"noise_freq": 0.06, "thres": 1}
+    param_ks_refine = {"sig": 0.05}
+    param_seeds_merge = {"thres_dist": 10, "thres_corr": 0.8, "noise_freq": 0.06}
+    param_initialize = {"thres_corr": 0.8, "wnd": 10, "noise_freq": 0.06}
+    param_init_merge = {"thres_corr": 0.8}
+    param_get_noise = {"noise_range": (0.06, 0.5)}
+    param_first_spatial = {"dl_wnd": 10, "sparse_penal": 0.01, "size_thres": (25, None)}
+    param_first_temporal = {
+        "noise_freq": 0.06, "sparse_penal": 1, "p": 1, "add_lag": 20, "jac_thres": 0.2,
+    }
+    param_first_merge = {"thres_corr": 0.8}
+    param_second_spatial = {"dl_wnd": 10, "sparse_penal": 0.01, "size_thres": (25, None)}
+    param_second_temporal = {
+        "noise_freq": 0.06, "sparse_penal": 1, "p": 1, "add_lag": 20, "jac_thres": 0.4,
+    }
+
+    # Preprocessing
+    dpath = os.path.abspath(dpath)
+    varr = load_videos(dpath, **param_load_videos)
+    chk, _ = get_optimal_chk(varr, dtype=float)
+    varr = save_minian(
+        varr.chunk({"frame": chk["frame"], "height": -1, "width": -1}).rename("varr"),
+        intpath, overwrite=True,
+    )
+    varr_ref = varr
+    varr_min = varr_ref.min("frame").compute()
+    varr_ref = varr_ref - varr_min
+    varr_ref = denoise(varr_ref, **param_denoise)
+    varr_ref = remove_background(varr_ref, **param_background_removal)
+    varr_ref = save_minian(varr_ref.rename("varr_ref"), dpath=intpath, overwrite=True)
+
+    # Motion correction
+    motion = estimate_motion(varr_ref, **param_estimate_motion)
+    motion = save_minian(
+        motion.rename("motion").chunk({"frame": chk["frame"]}), **param_save_minian,
+    )
+    Y = apply_transform(varr_ref, motion, fill=0)
+    Y_fm_chk = save_minian(Y.astype(float).rename("Y_fm_chk"), intpath, overwrite=True)
+    Y_hw_chk = save_minian(
+        Y_fm_chk.rename("Y_hw_chk"), intpath, overwrite=True,
+        chunks={"frame": -1, "height": chk["height"], "width": chk["width"]},
+    )
+    max_proj = save_minian(
+        Y_fm_chk.max("frame").rename("max_proj"), **param_save_minian
+    ).compute()
+
+    # Source detection
+    seeds = seeds_init(Y_fm_chk, **param_seeds_init)
+    seeds, pnr, gmm = pnr_refine(Y_hw_chk, seeds, **param_pnr_refine)
+    seeds = ks_refine(Y_hw_chk, seeds, **param_ks_refine)
+    seeds_final = seeds[seeds["mask_ks"] & seeds["mask_pnr"]].reset_index(drop=True)
+    seeds_final = seeds_merge(Y_hw_chk, max_proj, seeds_final, **param_seeds_merge)
+
+    A_init = initA(Y_hw_chk, seeds_final[seeds_final["mask_mrg"]], **param_initialize)
+    A_init = save_minian(A_init.rename("A_init"), intpath, overwrite=True)
+    C_init = initC(Y_fm_chk, A_init)
+    C_init = save_minian(
+        C_init.rename("C_init"), intpath, overwrite=True, chunks={"unit_id": 1, "frame": -1},
+    )
+
+    A, C = unit_merge(A_init, C_init, **param_init_merge)
+    A = save_minian(A.rename("A"), intpath, overwrite=True)
+    C = save_minian(C.rename("C"), intpath, overwrite=True)
+    C_chk = save_minian(
+        C.rename("C_chk"), intpath, overwrite=True,
+        chunks={"unit_id": -1, "frame": chk["frame"]},
+    )
+
+    b, f = update_background(Y_fm_chk, A, C_chk)
+    f = save_minian(f.rename("f"), intpath, overwrite=True)
+    b = save_minian(b.rename("b"), intpath, overwrite=True)
+
+    sn_spatial = get_noise_fft(Y_hw_chk, **param_get_noise)
+    sn_spatial = save_minian(sn_spatial.rename("sn_spatial"), intpath, overwrite=True)
+
+    # First spatial update
+    A_new, mask, norm_fac = update_spatial(Y_hw_chk, A, C, sn_spatial, **param_first_spatial)
+    C_new = save_minian(
+        (C.sel(unit_id=mask) * norm_fac).rename("C_new"), intpath, overwrite=True,
+    )
+    C_chk_new = save_minian(
+        (C_chk.sel(unit_id=mask) * norm_fac).rename("C_chk_new"), intpath, overwrite=True,
+    )
+    b_new, f_new = update_background(Y_fm_chk, A_new, C_chk_new)
+    A = save_minian(
+        A_new.rename("A"), intpath, overwrite=True,
+        chunks={"unit_id": 1, "height": -1, "width": -1},
+    )
+    b = save_minian(b_new.rename("b"), intpath, overwrite=True)
+    f = save_minian(f_new.chunk({"frame": chk["frame"]}).rename("f"), intpath, overwrite=True)
+    C = save_minian(C_new.rename("C"), intpath, overwrite=True)
+    C_chk = save_minian(C_chk_new.rename("C_chk"), intpath, overwrite=True)
+
+    # First temporal update
+    YrA = save_minian(
+        compute_trace(Y_fm_chk, A, b, C_chk, f).rename("YrA"),
+        intpath, overwrite=True, chunks={"unit_id": 1, "frame": -1},
+    )
+    C_new, S_new, b0_new, c0_new, g, mask = update_temporal(
+        A, C, YrA=YrA, **param_first_temporal,
+    )
+    C = save_minian(
+        C_new.rename("C").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True,
+    )
+    C_chk = save_minian(
+        C.rename("C_chk"), intpath, overwrite=True,
+        chunks={"unit_id": -1, "frame": chk["frame"]},
+    )
+    S = save_minian(
+        S_new.rename("S").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True,
+    )
+    b0 = save_minian(
+        b0_new.rename("b0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True,
+    )
+    c0 = save_minian(
+        c0_new.rename("c0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True,
+    )
+    A = A.sel(unit_id=C.coords["unit_id"].values)
+
+    # First merge
+    A_mrg, C_mrg, [sig_mrg] = unit_merge(A, C, [C + b0 + c0], **param_first_merge)
+    A = save_minian(A_mrg.rename("A_mrg"), intpath, overwrite=True)
+    C = save_minian(C_mrg.rename("C_mrg"), intpath, overwrite=True)
+    C_chk = save_minian(
+        C.rename("C_mrg_chk"), intpath, overwrite=True,
+        chunks={"unit_id": -1, "frame": chk["frame"]},
+    )
+    sig = save_minian(sig_mrg.rename("sig_mrg"), intpath, overwrite=True)
+
+    # Second spatial update
+    A_new, mask, norm_fac = update_spatial(Y_hw_chk, A, C, sn_spatial, **param_second_spatial)
+    C_new = save_minian(
+        (C.sel(unit_id=mask) * norm_fac).rename("C_new"), intpath, overwrite=True,
+    )
+    C_chk_new = save_minian(
+        (C_chk.sel(unit_id=mask) * norm_fac).rename("C_chk_new"), intpath, overwrite=True,
+    )
+    b_new, f_new = update_background(Y_fm_chk, A_new, C_chk_new)
+    A = save_minian(
+        A_new.rename("A"), intpath, overwrite=True,
+        chunks={"unit_id": 1, "height": -1, "width": -1},
+    )
+    b = save_minian(b_new.rename("b"), intpath, overwrite=True)
+    f = save_minian(f_new.chunk({"frame": chk["frame"]}).rename("f"), intpath, overwrite=True)
+    C = save_minian(C_new.rename("C"), intpath, overwrite=True)
+    C_chk = save_minian(C_chk_new.rename("C_chk"), intpath, overwrite=True)
+
+    # Second temporal update
+    YrA = save_minian(
+        compute_trace(Y_fm_chk, A, b, C_chk, f).rename("YrA"),
+        intpath, overwrite=True, chunks={"unit_id": 1, "frame": -1},
+    )
+    C_new, S_new, b0_new, c0_new, g, mask = update_temporal(
+        A, C, YrA=YrA, **param_second_temporal,
+    )
+    C = save_minian(
+        C_new.rename("C").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True,
+    )
+    C_chk = save_minian(
+        C.rename("C_chk"), intpath, overwrite=True,
+        chunks={"unit_id": -1, "frame": chk["frame"]},
+    )
+    S = save_minian(
+        S_new.rename("S").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True,
+    )
+    b0 = save_minian(
+        b0_new.rename("b0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True,
+    )
+    c0 = save_minian(
+        c0_new.rename("c0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True,
+    )
+    A = A.sel(unit_id=C.coords["unit_id"].values)
+
+    # Final saves
+    A = save_minian(A.rename("A"), **param_save_minian)
+    C = save_minian(C.rename("C"), **param_save_minian)
+    S = save_minian(S.rename("S"), **param_save_minian)
+    c0 = save_minian(c0.rename("c0"), **param_save_minian)
+    b0 = save_minian(b0.rename("b0"), **param_save_minian)
+    b = save_minian(b.rename("b"), **param_save_minian)
+    f = save_minian(f.rename("f"), **param_save_minian)
+
+    return A, C, S, b, f, b0, c0, motion, max_proj
+
+
+def _run_separated(dpath, intpath, minian_path):
+    """Run the 4-module separated pipeline chain."""
+    param_save_minian = {
+        "dpath": minian_path,
+        "meta_dict": dict(session=-1, animal=-2),
+        "overwrite": True,
+    }
+
+    config_pp = {
+        "intpath": intpath,
+        "subset": dict(frame=slice(0, None)),
+    }
+
+    # Module 1: Preprocessing
+    Y_bg, chk, cfg_pp = preprocess_video(dpath, config_pp)
+
+    # Module 2: Motion correction
+    cfg_mc_in = deepcopy(cfg_pp)
+    cfg_mc_in["param_save_minian"] = param_save_minian
+    Y_hw_chk, Y_fm_chk, motion, max_proj, cfg_mc = correct_motion(Y_bg, cfg_mc_in)
+
+    # Module 3: Source detection
+    cfg_sd_in = deepcopy(cfg_mc)
+    A, C, S, b, f, b0, c0, cfg_sd = detect_sources(
+        Y_hw_chk, Y_fm_chk, max_proj, cfg_sd_in
+    )
+
+    # Module 4: Component filtering
+    result = filter_components(A, C, S, b0, c0, cfg_sd)
+
+    return result.A, result.C, result.S, b, f, b0, c0, motion, max_proj
+
+
+@pytest.fixture
+def dask_client():
+    """Set up a Dask LocalCluster for testing."""
+    from dask.distributed import Client, LocalCluster
+
+    cluster = LocalCluster(
+        n_workers=2,
+        memory_limit="1GB",
+        threads_per_worker=1,
+    )
+    client = Client(cluster)
+    yield client
+    client.close()
+    cluster.close()
+
+
+@pytest.mark.slow
+def test_full_pipeline_chaining(dask_client):
+    """Chain all 4 modules and verify monolithic parity."""
+    tmpdir = tempfile.mkdtemp(prefix="minian_test_chain_")
+
+    try:
+        dpath = _make_temp_videos(tmpdir)
+
+        # Run separated chain
+        intpath_sep = os.path.join(tmpdir, "int_sep")
+        minian_sep = os.path.join(tmpdir, "minian_sep")
+        os.makedirs(minian_sep, exist_ok=True)
+        A_sep, C_sep, S_sep, b_sep, f_sep, b0_sep, c0_sep, motion_sep, mp_sep = (
+            _run_separated(dpath, intpath_sep, minian_sep)
+        )
+
+        # Run monolithic
+        intpath_mono = os.path.join(tmpdir, "int_mono")
+        minian_mono = os.path.join(tmpdir, "minian_mono")
+        os.makedirs(minian_mono, exist_ok=True)
+        A_mono, C_mono, S_mono, b_mono, f_mono, b0_mono, c0_mono, motion_mono, mp_mono = (
+            _run_monolithic(dpath, intpath_mono, minian_mono)
+        )
+
+        # Verify output types
+        assert isinstance(A_sep, xr.DataArray)
+        assert isinstance(C_sep, xr.DataArray)
+        assert isinstance(S_sep, xr.DataArray)
+
+        # Verify exact equality of gate metrics
+        assert A_sep.sizes == A_mono.sizes, (
+            f"A shape mismatch: {A_sep.sizes} != {A_mono.sizes}"
+        )
+
+        np.testing.assert_array_equal(
+            motion_sep.values, motion_mono.values,
+            err_msg="Motion estimates differ",
+        )
+        np.testing.assert_array_equal(
+            mp_sep.values, mp_mono.values,
+            err_msg="Max projections differ",
+        )
+        np.testing.assert_array_equal(
+            A_sep.values, A_mono.values,
+            err_msg="Spatial footprints (A) differ",
+        )
+        np.testing.assert_array_equal(
+            C_sep.values, C_mono.values,
+            err_msg="Temporal traces (C) differ",
+        )
+        np.testing.assert_array_equal(
+            S_sep.values, S_mono.values,
+            err_msg="Spikes (S) differ",
+        )
+
+        print(f"Units detected: {A_sep.sizes.get('unit_id', 0)}")
+        print(f"A sum: {int(A_sep.sum())}")
+        print(f"C sum: {int(C_sep.sum())}")
+        print(f"S sum: {int(S_sep.sum())}")
+        print("Cross-module chaining test PASSED!")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.mark.slow
+def test_chain_output_shapes(dask_client):
+    """Verify that chained modules produce reasonable output shapes."""
+    tmpdir = tempfile.mkdtemp(prefix="minian_test_shapes_")
+
+    try:
+        dpath = _make_temp_videos(tmpdir)
+        intpath = os.path.join(tmpdir, "intermediate")
+        minian_path = os.path.join(tmpdir, "minian")
+        os.makedirs(minian_path, exist_ok=True)
+
+        A, C, S, b, f, b0, c0, motion, max_proj = _run_separated(
+            dpath, intpath, minian_path
+        )
+
+        # Basic shape checks
+        assert "unit_id" in A.dims
+        assert "height" in A.dims
+        assert "width" in A.dims
+        assert "unit_id" in C.dims
+        assert "frame" in C.dims
+        assert "frame" in motion.dims
+        assert set(max_proj.dims) == {"height", "width"}
+
+        print("Chain output shapes test PASSED!")
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    from dask.distributed import Client, LocalCluster
+
+    cluster = LocalCluster(n_workers=2, memory_limit="1GB", threads_per_worker=1)
+    client = Client(cluster)
+    try:
+        tmpdir = tempfile.mkdtemp(prefix="minian_test_chain_")
+        try:
+            dpath = _make_temp_videos(tmpdir)
+            intpath = os.path.join(tmpdir, "intermediate")
+            minian_path = os.path.join(tmpdir, "minian")
+            os.makedirs(minian_path, exist_ok=True)
+            A, C, S, b, f, b0, c0, motion, max_proj = _run_separated(
+                dpath, intpath, minian_path
+            )
+            print(f"Units: {A.sizes.get('unit_id', 0)}")
+            print("Quick chain test PASSED!")
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+    finally:
+        client.close()
+        cluster.close()

--- a/separation/tools/run_separation_judgement.py
+++ b/separation/tools/run_separation_judgement.py
@@ -1,0 +1,666 @@
+#!/usr/bin/env python3
+"""Run monolithic-vs-separated parity judgement on real MiniAn demo data.
+
+Artifacts:
+- output/separation_judgement/{original,separated}/
+- output/separation_judgement/metrics.csv
+- output/separation_judgement/metrics.json
+- output/separation_judgement/pass_fail.csv
+- output/separation_judgement/timings.json
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import pickle
+import shutil
+import sys
+import time
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import xarray as xr
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = ROOT.parent
+
+# Add module paths
+sys.path.insert(0, str(ROOT / "preprocessing"))
+sys.path.insert(0, str(ROOT / "motion_correction"))
+sys.path.insert(0, str(ROOT / "source_detection"))
+sys.path.insert(0, str(ROOT / "component_filtering"))
+
+from component_filtering import FilterResult, filter_components as sep_filter
+from motion_correction import correct_motion as sep_correct_motion
+from preprocessing import preprocess_video as sep_preprocess
+from source_detection import detect_sources as sep_detect
+
+# Monolithic imports
+sys.path.insert(0, str(REPO_ROOT))
+from minian.cnmf import (
+    compute_trace,
+    get_noise_fft,
+    unit_merge,
+    update_background,
+    update_spatial,
+    update_temporal,
+)
+from minian.initialization import (
+    initA,
+    initC,
+    ks_refine,
+    pnr_refine,
+    seeds_init,
+    seeds_merge,
+)
+from minian.motion_correction import apply_transform, estimate_motion
+from minian.preprocessing import denoise, remove_background
+from minian.utilities import (
+    get_optimal_chk,
+    load_videos,
+    open_minian,
+    save_minian,
+)
+
+# Default demo data paths
+DEMO_DPATH = Path("/mnt/nas02/Dataset/minian/demo_movies")
+LOCAL_DPATH = REPO_ROOT / "demo_movies"
+
+# Default parameters matching pipeline.ipynb
+BASE_CONFIG = {
+    "param_load_videos": {
+        "pattern": r"msCam[0-9]+\.avi$",
+        "dtype": np.uint8,
+        "downsample": dict(frame=1, height=1, width=1),
+        "downsample_strategy": "subset",
+    },
+    "param_denoise": {"method": "median", "ksize": 7},
+    "param_background_removal": {"method": "tophat", "wnd": 15},
+    "param_estimate_motion": {"dim": "frame"},
+    "subset": dict(frame=slice(0, None)),
+    "subset_mc": None,
+    "param_seeds_init": {
+        "wnd_size": 1000, "method": "rolling", "stp_size": 500,
+        "max_wnd": 15, "diff_thres": 3,
+    },
+    "param_pnr_refine": {"noise_freq": 0.06, "thres": 1},
+    "param_ks_refine": {"sig": 0.05},
+    "param_seeds_merge": {"thres_dist": 10, "thres_corr": 0.8, "noise_freq": 0.06},
+    "param_initialize": {"thres_corr": 0.8, "wnd": 10, "noise_freq": 0.06},
+    "param_init_merge": {"thres_corr": 0.8},
+    "param_get_noise": {"noise_range": (0.06, 0.5)},
+    "param_first_spatial": {"dl_wnd": 10, "sparse_penal": 0.01, "size_thres": (25, None)},
+    "param_first_temporal": {
+        "noise_freq": 0.06, "sparse_penal": 1, "p": 1, "add_lag": 20, "jac_thres": 0.2,
+    },
+    "param_first_merge": {"thres_corr": 0.8},
+    "param_second_spatial": {"dl_wnd": 10, "sparse_penal": 0.01, "size_thres": (25, None)},
+    "param_second_temporal": {
+        "noise_freq": 0.06, "sparse_penal": 1, "p": 1, "add_lag": 20, "jac_thres": 0.4,
+    },
+}
+
+
+@dataclass
+class StageOutputs:
+    """Collected outputs from all pipeline stages."""
+    motion: np.ndarray
+    max_proj: np.ndarray
+    A: np.ndarray
+    C: np.ndarray
+    S: np.ndarray
+    b: np.ndarray
+    f: np.ndarray
+    b0: np.ndarray
+    c0: np.ndarray
+    n_units: int
+    labels: Optional[np.ndarray] = None
+    metrics: Optional[Dict[str, np.ndarray]] = None
+
+
+def safe_float(v: Any) -> Optional[float]:
+    if v is None:
+        return None
+    try:
+        f = float(v)
+    except Exception:
+        return None
+    if math.isnan(f) or math.isinf(f):
+        return None
+    return f
+
+
+def compare_arrays(
+    a: np.ndarray, b: np.ndarray,
+) -> Tuple[bool, Optional[float], Optional[float], str]:
+    arr_a = np.asarray(a)
+    arr_b = np.asarray(b)
+    if arr_a.shape != arr_b.shape:
+        return False, None, None, f"shape_mismatch:{arr_a.shape}!={arr_b.shape}"
+
+    exact = bool(np.array_equal(arr_a, arr_b))
+    if arr_a.size == 0:
+        return exact, 0.0, None, "empty"
+
+    a64 = arr_a.astype(np.float64, copy=False)
+    b64 = arr_b.astype(np.float64, copy=False)
+    max_abs = safe_float(np.max(np.abs(a64 - b64)))
+
+    if arr_a.size < 2:
+        corr = None
+    else:
+        std_a, std_b = float(np.std(a64)), float(np.std(b64))
+        if std_a == 0.0 and std_b == 0.0:
+            corr = 1.0 if exact else None
+        elif std_a == 0.0 or std_b == 0.0:
+            corr = None
+        else:
+            corr = safe_float(np.corrcoef(a64.ravel(), b64.ravel())[0, 1])
+
+    return exact, max_abs, corr, "ok"
+
+
+def compare_scalars(a: Any, b: Any) -> Tuple[bool, str]:
+    exact = a == b
+    return bool(exact), "ok" if exact else f"value_mismatch:{a}!={b}"
+
+
+def image_ssim(a: np.ndarray, b: np.ndarray) -> Optional[float]:
+    try:
+        from skimage.metrics import structural_similarity
+    except ImportError:
+        return None
+    arr_a = np.asarray(a, dtype=np.float64)
+    arr_b = np.asarray(b, dtype=np.float64)
+    if arr_a.shape != arr_b.shape or arr_a.ndim != 2 or arr_a.size == 0:
+        return None
+    data_min = float(min(np.min(arr_a), np.min(arr_b)))
+    data_max = float(max(np.max(arr_a), np.max(arr_b)))
+    data_range = data_max - data_min
+    if data_range == 0.0:
+        return 1.0 if np.array_equal(arr_a, arr_b) else 0.0
+    return safe_float(structural_similarity(arr_a, arr_b, data_range=data_range))
+
+
+def ensure_clean_dir(path: Path) -> None:
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def run_original(dpath: str, intpath: str, minian_path: str) -> StageOutputs:
+    """Run monolithic pipeline programmatically (same steps as pipeline.ipynb)."""
+    cfg = deepcopy(BASE_CONFIG)
+    param_save_minian = {
+        "dpath": minian_path,
+        "meta_dict": dict(session=-1, animal=-2),
+        "overwrite": True,
+    }
+
+    os.environ["MINIAN_INTERMEDIATE"] = intpath
+    dpath = os.path.abspath(dpath)
+
+    # Preprocessing
+    varr = load_videos(dpath, **cfg["param_load_videos"])
+    chk, _ = get_optimal_chk(varr, dtype=float)
+    varr = save_minian(
+        varr.chunk({"frame": chk["frame"], "height": -1, "width": -1}).rename("varr"),
+        intpath, overwrite=True,
+    )
+    varr_ref = varr.sel(cfg["subset"])
+    varr_min = varr_ref.min("frame").compute()
+    varr_ref = varr_ref - varr_min
+    varr_ref = denoise(varr_ref, **cfg["param_denoise"])
+    varr_ref = remove_background(varr_ref, **cfg["param_background_removal"])
+    varr_ref = save_minian(varr_ref.rename("varr_ref"), dpath=intpath, overwrite=True)
+
+    # Motion correction
+    motion = estimate_motion(varr_ref, **cfg["param_estimate_motion"])
+    motion = save_minian(
+        motion.rename("motion").chunk({"frame": chk["frame"]}), **param_save_minian,
+    )
+    Y = apply_transform(varr_ref, motion, fill=0)
+    Y_fm_chk = save_minian(Y.astype(float).rename("Y_fm_chk"), intpath, overwrite=True)
+    Y_hw_chk = save_minian(
+        Y_fm_chk.rename("Y_hw_chk"), intpath, overwrite=True,
+        chunks={"frame": -1, "height": chk["height"], "width": chk["width"]},
+    )
+    max_proj = save_minian(
+        Y_fm_chk.max("frame").rename("max_proj"), **param_save_minian,
+    ).compute()
+
+    # Source detection (full CNMF)
+    seeds = seeds_init(Y_fm_chk, **cfg["param_seeds_init"])
+    seeds, pnr, gmm = pnr_refine(Y_hw_chk, seeds, **cfg["param_pnr_refine"])
+    seeds = ks_refine(Y_hw_chk, seeds, **cfg["param_ks_refine"])
+    seeds_final = seeds[seeds["mask_ks"] & seeds["mask_pnr"]].reset_index(drop=True)
+    seeds_final = seeds_merge(Y_hw_chk, max_proj, seeds_final, **cfg["param_seeds_merge"])
+
+    A_init = initA(Y_hw_chk, seeds_final[seeds_final["mask_mrg"]], **cfg["param_initialize"])
+    A_init = save_minian(A_init.rename("A_init"), intpath, overwrite=True)
+    C_init = initC(Y_fm_chk, A_init)
+    C_init = save_minian(
+        C_init.rename("C_init"), intpath, overwrite=True, chunks={"unit_id": 1, "frame": -1},
+    )
+    A, C = unit_merge(A_init, C_init, **cfg["param_init_merge"])
+    A = save_minian(A.rename("A"), intpath, overwrite=True)
+    C = save_minian(C.rename("C"), intpath, overwrite=True)
+    C_chk = save_minian(
+        C.rename("C_chk"), intpath, overwrite=True,
+        chunks={"unit_id": -1, "frame": chk["frame"]},
+    )
+
+    b, f = update_background(Y_fm_chk, A, C_chk)
+    f = save_minian(f.rename("f"), intpath, overwrite=True)
+    b = save_minian(b.rename("b"), intpath, overwrite=True)
+
+    sn_spatial = get_noise_fft(Y_hw_chk, **cfg["param_get_noise"])
+    sn_spatial = save_minian(sn_spatial.rename("sn_spatial"), intpath, overwrite=True)
+
+    # First spatial
+    A_new, mask, norm_fac = update_spatial(Y_hw_chk, A, C, sn_spatial, **cfg["param_first_spatial"])
+    C_new = save_minian((C.sel(unit_id=mask) * norm_fac).rename("C_new"), intpath, overwrite=True)
+    C_chk_new = save_minian((C_chk.sel(unit_id=mask) * norm_fac).rename("C_chk_new"), intpath, overwrite=True)
+    b_new, f_new = update_background(Y_fm_chk, A_new, C_chk_new)
+    A = save_minian(A_new.rename("A"), intpath, overwrite=True, chunks={"unit_id": 1, "height": -1, "width": -1})
+    b = save_minian(b_new.rename("b"), intpath, overwrite=True)
+    f = save_minian(f_new.chunk({"frame": chk["frame"]}).rename("f"), intpath, overwrite=True)
+    C = save_minian(C_new.rename("C"), intpath, overwrite=True)
+    C_chk = save_minian(C_chk_new.rename("C_chk"), intpath, overwrite=True)
+
+    # First temporal
+    YrA = save_minian(
+        compute_trace(Y_fm_chk, A, b, C_chk, f).rename("YrA"),
+        intpath, overwrite=True, chunks={"unit_id": 1, "frame": -1},
+    )
+    C_new, S_new, b0_new, c0_new, g, mask = update_temporal(A, C, YrA=YrA, **cfg["param_first_temporal"])
+    C = save_minian(C_new.rename("C").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
+    C_chk = save_minian(C.rename("C_chk"), intpath, overwrite=True, chunks={"unit_id": -1, "frame": chk["frame"]})
+    S = save_minian(S_new.rename("S").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
+    b0 = save_minian(b0_new.rename("b0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
+    c0 = save_minian(c0_new.rename("c0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
+    A = A.sel(unit_id=C.coords["unit_id"].values)
+
+    # First merge
+    A_mrg, C_mrg, [sig_mrg] = unit_merge(A, C, [C + b0 + c0], **cfg["param_first_merge"])
+    A = save_minian(A_mrg.rename("A_mrg"), intpath, overwrite=True)
+    C = save_minian(C_mrg.rename("C_mrg"), intpath, overwrite=True)
+    C_chk = save_minian(C.rename("C_mrg_chk"), intpath, overwrite=True, chunks={"unit_id": -1, "frame": chk["frame"]})
+    sig = save_minian(sig_mrg.rename("sig_mrg"), intpath, overwrite=True)
+
+    # Second spatial
+    A_new, mask, norm_fac = update_spatial(Y_hw_chk, A, C, sn_spatial, **cfg["param_second_spatial"])
+    C_new = save_minian((C.sel(unit_id=mask) * norm_fac).rename("C_new"), intpath, overwrite=True)
+    C_chk_new = save_minian((C_chk.sel(unit_id=mask) * norm_fac).rename("C_chk_new"), intpath, overwrite=True)
+    b_new, f_new = update_background(Y_fm_chk, A_new, C_chk_new)
+    A = save_minian(A_new.rename("A"), intpath, overwrite=True, chunks={"unit_id": 1, "height": -1, "width": -1})
+    b = save_minian(b_new.rename("b"), intpath, overwrite=True)
+    f = save_minian(f_new.chunk({"frame": chk["frame"]}).rename("f"), intpath, overwrite=True)
+    C = save_minian(C_new.rename("C"), intpath, overwrite=True)
+    C_chk = save_minian(C_chk_new.rename("C_chk"), intpath, overwrite=True)
+
+    # Second temporal
+    YrA = save_minian(
+        compute_trace(Y_fm_chk, A, b, C_chk, f).rename("YrA"),
+        intpath, overwrite=True, chunks={"unit_id": 1, "frame": -1},
+    )
+    C_new, S_new, b0_new, c0_new, g, mask = update_temporal(A, C, YrA=YrA, **cfg["param_second_temporal"])
+    C = save_minian(C_new.rename("C").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
+    C_chk = save_minian(C.rename("C_chk"), intpath, overwrite=True, chunks={"unit_id": -1, "frame": chk["frame"]})
+    S = save_minian(S_new.rename("S").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
+    b0 = save_minian(b0_new.rename("b0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
+    c0 = save_minian(c0_new.rename("c0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
+    A = A.sel(unit_id=C.coords["unit_id"].values)
+
+    # Final saves
+    A = save_minian(A.rename("A"), **param_save_minian)
+    C = save_minian(C.rename("C"), **param_save_minian)
+    S = save_minian(S.rename("S"), **param_save_minian)
+    c0 = save_minian(c0.rename("c0"), **param_save_minian)
+    b0 = save_minian(b0.rename("b0"), **param_save_minian)
+    b = save_minian(b.rename("b"), **param_save_minian)
+    f = save_minian(f.rename("f"), **param_save_minian)
+
+    return StageOutputs(
+        motion=np.asarray(motion.values),
+        max_proj=np.asarray(max_proj.values),
+        A=np.asarray(A.compute().values),
+        C=np.asarray(C.compute().values),
+        S=np.asarray(S.compute().values),
+        b=np.asarray(b.compute().values),
+        f=np.asarray(f.compute().values),
+        b0=np.asarray(b0.compute().values),
+        c0=np.asarray(c0.compute().values),
+        n_units=int(A.sizes["unit_id"]),
+    )
+
+
+def run_separated(dpath: str, intpath: str, minian_path: str) -> StageOutputs:
+    """Run the 4-module separated chain."""
+    param_save_minian = {
+        "dpath": minian_path,
+        "meta_dict": dict(session=-1, animal=-2),
+        "overwrite": True,
+    }
+
+    config_pp = deepcopy(BASE_CONFIG)
+    config_pp["intpath"] = intpath
+
+    # Module 1
+    Y_bg, chk, cfg_pp = sep_preprocess(dpath, config_pp)
+
+    # Module 2
+    cfg_mc = deepcopy(cfg_pp)
+    cfg_mc["param_save_minian"] = param_save_minian
+    Y_hw, Y_fm, motion, max_proj, cfg_mc_out = sep_correct_motion(Y_bg, cfg_mc)
+
+    # Module 3
+    cfg_sd = deepcopy(cfg_mc_out)
+    A, C, S, b, f, b0, c0, cfg_sd_out = sep_detect(Y_hw, Y_fm, max_proj, cfg_sd)
+
+    # Module 4
+    result = sep_filter(A, C, S, b0, c0, cfg_sd_out)
+
+    return StageOutputs(
+        motion=np.asarray(motion.compute().values if hasattr(motion, "compute") else motion.values),
+        max_proj=np.asarray(max_proj.values if hasattr(max_proj, "values") else max_proj),
+        A=np.asarray(result.A.compute().values if hasattr(result.A, "compute") else result.A.values),
+        C=np.asarray(result.C.compute().values if hasattr(result.C, "compute") else result.C.values),
+        S=np.asarray(result.S.compute().values if hasattr(result.S, "compute") else result.S.values),
+        b=np.asarray(b.compute().values if hasattr(b, "compute") else b.values),
+        f=np.asarray(f.compute().values if hasattr(f, "compute") else f.values),
+        b0=np.asarray(b0.compute().values if hasattr(b0, "compute") else b0.values),
+        c0=np.asarray(c0.compute().values if hasattr(c0, "compute") else c0.values),
+        n_units=int(result.A.sizes.get("unit_id", 0)),
+        labels=result.labels,
+        metrics=result.metrics,
+    )
+
+
+def add_array_row(
+    rows: List[Dict[str, Any]], dataset: str, module: str, target: str,
+    arr_a: np.ndarray, arr_b: np.ndarray, gate: bool,
+) -> None:
+    exact, max_abs, corr, note = compare_arrays(arr_a, arr_b)
+    rows.append({
+        "dataset": dataset, "module": module, "target": target,
+        "is_gate": gate,
+        "pass": bool(exact) if gate else None,
+        "exact_equal": bool(exact),
+        "max_abs_error": max_abs, "pearson_corr": corr,
+        "ssim": None, "note": note,
+    })
+
+
+def add_scalar_row(
+    rows: List[Dict[str, Any]], dataset: str, module: str, target: str,
+    a: Any, b: Any, gate: bool,
+) -> None:
+    exact, note = compare_scalars(a, b)
+    rows.append({
+        "dataset": dataset, "module": module, "target": target,
+        "is_gate": gate,
+        "pass": bool(exact) if gate else None,
+        "exact_equal": bool(exact),
+        "max_abs_error": 0.0 if exact else None,
+        "pearson_corr": None, "ssim": None, "note": note,
+    })
+
+
+def add_ssim_row(
+    rows: List[Dict[str, Any]], dataset: str, module: str, target: str,
+    img_a: np.ndarray, img_b: np.ndarray,
+) -> None:
+    rows.append({
+        "dataset": dataset, "module": module, "target": target,
+        "is_gate": False, "pass": None, "exact_equal": None,
+        "max_abs_error": None, "pearson_corr": None,
+        "ssim": image_ssim(img_a, img_b), "note": "ssim",
+    })
+
+
+def compute_metrics(
+    dataset_name: str, original: StageOutputs, separated: StageOutputs,
+) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+
+    # Motion correction
+    add_array_row(rows, dataset_name, "motion_correction", "motion",
+                  original.motion, separated.motion, gate=True)
+    add_array_row(rows, dataset_name, "motion_correction", "max_proj",
+                  original.max_proj, separated.max_proj, gate=True)
+    add_ssim_row(rows, dataset_name, "motion_correction", "max_proj_ssim",
+                 original.max_proj, separated.max_proj)
+
+    # Source detection
+    add_array_row(rows, dataset_name, "source_detection", "A",
+                  original.A, separated.A, gate=True)
+    add_array_row(rows, dataset_name, "source_detection", "C",
+                  original.C, separated.C, gate=True)
+    add_array_row(rows, dataset_name, "source_detection", "S",
+                  original.S, separated.S, gate=True)
+    add_scalar_row(rows, dataset_name, "source_detection", "n_units",
+                   original.n_units, separated.n_units, gate=True)
+
+    # Component filtering
+    if separated.labels is not None:
+        add_scalar_row(rows, dataset_name, "component_filtering", "all_accepted",
+                       True, bool(np.all(separated.labels == 1)), gate=False)
+
+    # Ground truth checks
+    add_scalar_row(rows, dataset_name, "ground_truth", "A_sum",
+                   int(np.sum(original.A)), int(np.sum(separated.A)), gate=True)
+    add_scalar_row(rows, dataset_name, "ground_truth", "C_sum",
+                   int(np.sum(original.C)), int(np.sum(separated.C)), gate=True)
+    add_scalar_row(rows, dataset_name, "ground_truth", "S_sum",
+                   int(np.sum(original.S)), int(np.sum(separated.S)), gate=True)
+
+    return rows
+
+
+def write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fieldnames = [
+        "dataset", "module", "target", "is_gate", "pass",
+        "exact_equal", "max_abs_error", "pearson_corr", "ssim", "note",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def build_pass_fail(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    grouped: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    for row in rows:
+        key = (row["dataset"], row["module"])
+        grouped.setdefault(key, []).append(row)
+
+    summary: List[Dict[str, Any]] = []
+    for (dataset, module), module_rows in sorted(grouped.items()):
+        gate_rows = [r for r in module_rows if r["is_gate"]]
+        if not gate_rows:
+            passed = True
+            failed_targets: List[str] = []
+        else:
+            failed_targets = [r["target"] for r in gate_rows if not r["pass"]]
+            passed = len(failed_targets) == 0
+        summary.append({
+            "dataset": dataset, "module": module,
+            "pass": passed, "failed_targets": ";".join(failed_targets),
+        })
+    return summary
+
+
+def write_pass_fail_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    fieldnames = ["dataset", "module", "pass", "failed_targets"]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def save_stage_outputs(base_dir: Path, outputs: StageOutputs) -> None:
+    base_dir.mkdir(parents=True, exist_ok=True)
+    np.save(base_dir / "motion.npy", outputs.motion)
+    np.save(base_dir / "max_proj.npy", outputs.max_proj)
+    np.save(base_dir / "A.npy", outputs.A)
+    np.save(base_dir / "C.npy", outputs.C)
+    np.save(base_dir / "S.npy", outputs.S)
+    np.save(base_dir / "b.npy", outputs.b)
+    np.save(base_dir / "f.npy", outputs.f)
+    np.save(base_dir / "b0.npy", outputs.b0)
+    np.save(base_dir / "c0.npy", outputs.c0)
+    if outputs.labels is not None:
+        np.save(base_dir / "labels.npy", outputs.labels)
+    if outputs.metrics is not None:
+        for k, v in outputs.metrics.items():
+            np.save(base_dir / f"metric_{k}.npy", v)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run MiniAn separation judgement parity workflow."
+    )
+    parser.add_argument(
+        "--dpath",
+        default=None,
+        help="Path to demo_movies directory. Auto-detected if not set.",
+    )
+    parser.add_argument(
+        "--output-root",
+        default=str(REPO_ROOT / "output" / "separation_judgement"),
+        help="Artifact root directory.",
+    )
+    parser.add_argument(
+        "--n-workers",
+        type=int,
+        default=int(os.getenv("MINIAN_NWORKERS", 4)),
+        help="Number of Dask workers.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    output_root = Path(args.output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    # Determine data path
+    dpath = args.dpath
+    if dpath is None:
+        if LOCAL_DPATH.exists():
+            dpath = str(LOCAL_DPATH)
+        elif DEMO_DPATH.exists():
+            dpath = str(DEMO_DPATH)
+        else:
+            raise RuntimeError(
+                "No demo data found. Provide --dpath or place data at "
+                f"{LOCAL_DPATH} or {DEMO_DPATH}"
+            )
+    print(f"Using data path: {dpath}", flush=True)
+
+    # Set up threading limits
+    os.environ["OMP_NUM_THREADS"] = "1"
+    os.environ["MKL_NUM_THREADS"] = "1"
+    os.environ["OPENBLAS_NUM_THREADS"] = "1"
+
+    # Start Dask client
+    from dask.distributed import Client, LocalCluster
+    from minian.utilities import TaskAnnotation
+
+    cluster = LocalCluster(
+        n_workers=args.n_workers,
+        memory_limit="2GB",
+        resources={"MEM": 1},
+        threads_per_worker=2,
+        dashboard_address=":8787",
+    )
+    annt_plugin = TaskAnnotation()
+    cluster.scheduler.add_plugin(annt_plugin)
+    client = Client(cluster)
+    print(f"Dask dashboard: {client.dashboard_link}", flush=True)
+
+    dataset_name = "demo_movies"
+    all_rows: List[Dict[str, Any]] = []
+    timings: Dict[str, float] = {}
+
+    try:
+        # Run original
+        intpath_orig = str(output_root / "original" / "intermediate")
+        minian_orig = str(output_root / "original" / "minian")
+        os.makedirs(minian_orig, exist_ok=True)
+
+        print("\n=== Running ORIGINAL (monolithic) pipeline ===", flush=True)
+        t0 = time.time()
+        original = run_original(dpath, intpath_orig, minian_orig)
+        timings["original_sec"] = time.time() - t0
+        print(f"Original done in {timings['original_sec']:.2f}s", flush=True)
+        print(f"  units={original.n_units}, A_sum={int(np.sum(original.A))}, "
+              f"C_sum={int(np.sum(original.C))}, S_sum={int(np.sum(original.S))}", flush=True)
+
+        # Run separated
+        intpath_sep = str(output_root / "separated" / "intermediate")
+        minian_sep = str(output_root / "separated" / "minian")
+        os.makedirs(minian_sep, exist_ok=True)
+
+        print("\n=== Running SEPARATED (4-module chain) pipeline ===", flush=True)
+        t1 = time.time()
+        separated = run_separated(dpath, intpath_sep, minian_sep)
+        timings["separated_sec"] = time.time() - t1
+        print(f"Separated done in {timings['separated_sec']:.2f}s", flush=True)
+        print(f"  units={separated.n_units}, A_sum={int(np.sum(separated.A))}, "
+              f"C_sum={int(np.sum(separated.C))}, S_sum={int(np.sum(separated.S))}", flush=True)
+
+        # Save outputs
+        save_stage_outputs(output_root / "original" / dataset_name, original)
+        save_stage_outputs(output_root / "separated" / dataset_name, separated)
+
+        # Compute metrics
+        rows = compute_metrics(dataset_name, original, separated)
+        all_rows.extend(rows)
+
+        # Report
+        pf_rows = build_pass_fail(rows)
+        all_pass = all(r["pass"] for r in pf_rows)
+        print(f"\nOverall PASS: {all_pass}", flush=True)
+        for r in pf_rows:
+            status = "PASS" if r["pass"] else f"FAIL ({r['failed_targets']})"
+            print(f"  {r['module']}: {status}", flush=True)
+
+    finally:
+        client.close()
+        cluster.close()
+
+    # Write artifacts
+    metrics_csv = output_root / "metrics.csv"
+    metrics_json = output_root / "metrics.json"
+    pass_fail_csv = output_root / "pass_fail.csv"
+    timings_json = output_root / "timings.json"
+
+    write_csv(metrics_csv, all_rows)
+    with metrics_json.open("w", encoding="utf-8") as f:
+        json.dump(all_rows, f, indent=2)
+
+    pass_fail_rows = build_pass_fail(all_rows)
+    write_pass_fail_csv(pass_fail_csv, pass_fail_rows)
+    with timings_json.open("w", encoding="utf-8") as f:
+        json.dump(timings, f, indent=2)
+
+    print(f"\nWrote: {metrics_csv}")
+    print(f"Wrote: {metrics_json}")
+    print(f"Wrote: {pass_fail_csv}")
+    print(f"Wrote: {timings_json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/separation_judgement.ipynb
+++ b/separation_judgement.ipynb
@@ -1,0 +1,321 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MiniAn Pipeline Separation Judgement\n",
+    "\n",
+    "This notebook loads the metrics and pass/fail results from\n",
+    "`separation/tools/run_separation_judgement.py` and produces\n",
+    "visualizations comparing the monolithic and separated pipelines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "%matplotlib inline\n",
+    "plt.rcParams['figure.figsize'] = (12, 6)\n",
+    "plt.rcParams['figure.dpi'] = 100"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Load Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_root = Path('output/separation_judgement')\n",
+    "\n",
+    "metrics_csv = output_root / 'metrics.csv'\n",
+    "pass_fail_csv = output_root / 'pass_fail.csv'\n",
+    "timings_json = output_root / 'timings.json'\n",
+    "\n",
+    "assert metrics_csv.exists(), f'Run separation/tools/run_separation_judgement.py first. Missing: {metrics_csv}'\n",
+    "\n",
+    "df_metrics = pd.read_csv(metrics_csv)\n",
+    "df_pass_fail = pd.read_csv(pass_fail_csv)\n",
+    "\n",
+    "with open(timings_json) as f:\n",
+    "    timings = json.load(f)\n",
+    "\n",
+    "print(f'Metrics rows: {len(df_metrics)}')\n",
+    "print(f'Pass/Fail rows: {len(df_pass_fail)}')\n",
+    "print(f'Timings: {timings}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Pass/Fail Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display pass/fail table with color coding\n",
+    "def highlight_pass_fail(val):\n",
+    "    if val == True or val == 'True':\n",
+    "        return 'background-color: #90EE90'\n",
+    "    elif val == False or val == 'False':\n",
+    "        return 'background-color: #FFB6C1'\n",
+    "    return ''\n",
+    "\n",
+    "styled = df_pass_fail.style.applymap(highlight_pass_fail, subset=['pass'])\n",
+    "display(styled)\n",
+    "\n",
+    "all_pass = df_pass_fail['pass'].all()\n",
+    "print(f'\\nOverall verdict: {\"PASS\" if all_pass else \"FAIL\"}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Detailed Gate Metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show all gate metrics\n",
+    "gate_df = df_metrics[df_metrics['is_gate'] == True].copy()\n",
+    "display(gate_df[['module', 'target', 'exact_equal', 'max_abs_error', 'pearson_corr', 'note']])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Spatial Footprint Comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = 'demo_movies'\n",
+    "orig_dir = output_root / 'original' / dataset\n",
+    "sep_dir = output_root / 'separated' / dataset\n",
+    "\n",
+    "if orig_dir.exists() and sep_dir.exists():\n",
+    "    A_orig = np.load(orig_dir / 'A.npy')\n",
+    "    A_sep = np.load(sep_dir / 'A.npy')\n",
+    "    \n",
+    "    fig, axes = plt.subplots(1, 3, figsize=(18, 5))\n",
+    "    \n",
+    "    # Max projection of spatial footprints\n",
+    "    proj_orig = np.max(A_orig, axis=0) if A_orig.ndim == 3 else A_orig\n",
+    "    proj_sep = np.max(A_sep, axis=0) if A_sep.ndim == 3 else A_sep\n",
+    "    \n",
+    "    axes[0].imshow(proj_orig, cmap='viridis')\n",
+    "    axes[0].set_title(f'Original (n={A_orig.shape[0]})')\n",
+    "    axes[0].axis('off')\n",
+    "    \n",
+    "    axes[1].imshow(proj_sep, cmap='viridis')\n",
+    "    axes[1].set_title(f'Separated (n={A_sep.shape[0]})')\n",
+    "    axes[1].axis('off')\n",
+    "    \n",
+    "    # Difference map\n",
+    "    if proj_orig.shape == proj_sep.shape:\n",
+    "        diff = proj_orig - proj_sep\n",
+    "        im = axes[2].imshow(diff, cmap='RdBu_r', vmin=-np.max(np.abs(diff)), vmax=np.max(np.abs(diff)))\n",
+    "        axes[2].set_title(f'Difference (max={np.max(np.abs(diff)):.6f})')\n",
+    "        plt.colorbar(im, ax=axes[2])\n",
+    "    else:\n",
+    "        axes[2].text(0.5, 0.5, 'Shape mismatch', ha='center', va='center', transform=axes[2].transAxes)\n",
+    "    axes[2].axis('off')\n",
+    "    \n",
+    "    plt.suptitle('Spatial Footprint Comparison (A max projection)', fontsize=14)\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print('Output directories not found. Run the judgement script first.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Temporal Trace Comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if orig_dir.exists() and sep_dir.exists():\n",
+    "    C_orig = np.load(orig_dir / 'C.npy')\n",
+    "    C_sep = np.load(sep_dir / 'C.npy')\n",
+    "    \n",
+    "    n_show = min(5, C_orig.shape[0], C_sep.shape[0])\n",
+    "    \n",
+    "    fig, axes = plt.subplots(n_show, 1, figsize=(14, 3 * n_show), sharex=True)\n",
+    "    if n_show == 1:\n",
+    "        axes = [axes]\n",
+    "    \n",
+    "    for i in range(n_show):\n",
+    "        axes[i].plot(C_orig[i], label='Original', alpha=0.8)\n",
+    "        axes[i].plot(C_sep[i], label='Separated', alpha=0.8, linestyle='--')\n",
+    "        axes[i].set_ylabel(f'Unit {i}')\n",
+    "        if i == 0:\n",
+    "            axes[i].legend()\n",
+    "    \n",
+    "    axes[-1].set_xlabel('Frame')\n",
+    "    plt.suptitle('Temporal Trace Comparison (C)', fontsize=14)\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print('Output directories not found.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Motion Correction Comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if orig_dir.exists() and sep_dir.exists():\n",
+    "    motion_orig = np.load(orig_dir / 'motion.npy')\n",
+    "    motion_sep = np.load(sep_dir / 'motion.npy')\n",
+    "    \n",
+    "    fig, axes = plt.subplots(1, 2, figsize=(14, 4))\n",
+    "    \n",
+    "    for dim in range(motion_orig.shape[1]):\n",
+    "        label = ['height', 'width'][dim]\n",
+    "        axes[0].plot(motion_orig[:, dim], label=f'Orig {label}')\n",
+    "        axes[0].plot(motion_sep[:, dim], '--', label=f'Sep {label}')\n",
+    "    axes[0].set_title('Motion Shifts')\n",
+    "    axes[0].set_xlabel('Frame')\n",
+    "    axes[0].set_ylabel('Shift (pixels)')\n",
+    "    axes[0].legend()\n",
+    "    \n",
+    "    diff = motion_orig - motion_sep\n",
+    "    axes[1].plot(diff)\n",
+    "    axes[1].set_title(f'Motion Difference (max abs={np.max(np.abs(diff)):.6f})')\n",
+    "    axes[1].set_xlabel('Frame')\n",
+    "    axes[1].set_ylabel('Difference')\n",
+    "    \n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print('Output directories not found.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Correlation and SSIM Statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Summary statistics\n",
+    "print('=== Correlation Statistics ===')\n",
+    "corr_vals = df_metrics['pearson_corr'].dropna()\n",
+    "if len(corr_vals) > 0:\n",
+    "    print(f'  Mean: {corr_vals.mean():.6f}')\n",
+    "    print(f'  Min:  {corr_vals.min():.6f}')\n",
+    "    print(f'  Max:  {corr_vals.max():.6f}')\n",
+    "\n",
+    "print('\\n=== SSIM Statistics ===')\n",
+    "ssim_vals = df_metrics['ssim'].dropna()\n",
+    "if len(ssim_vals) > 0:\n",
+    "    print(f'  Mean: {ssim_vals.mean():.6f}')\n",
+    "    print(f'  Min:  {ssim_vals.min():.6f}')\n",
+    "    print(f'  Max:  {ssim_vals.max():.6f}')\n",
+    "\n",
+    "print('\\n=== Max Absolute Error ===')\n",
+    "mae_vals = df_metrics['max_abs_error'].dropna()\n",
+    "if len(mae_vals) > 0:\n",
+    "    print(f'  Mean: {mae_vals.mean():.6f}')\n",
+    "    print(f'  Max:  {mae_vals.max():.6f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Final Verdict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gate_results = df_metrics[df_metrics['is_gate'] == True]\n",
+    "n_gates = len(gate_results)\n",
+    "n_pass = gate_results['exact_equal'].sum()\n",
+    "n_fail = n_gates - n_pass\n",
+    "\n",
+    "print(f'Gate metrics: {n_pass}/{n_gates} PASS')\n",
+    "if n_fail > 0:\n",
+    "    print(f'\\nFailed gates:')\n",
+    "    failed = gate_results[gate_results['exact_equal'] == False]\n",
+    "    for _, row in failed.iterrows():\n",
+    "        print(f'  {row[\"module\"]}/{row[\"target\"]}: {row[\"note\"]}')\n",
+    "    print(f'\\nVERDICT: FAIL')\n",
+    "else:\n",
+    "    print(f'\\nVERDICT: PASS — Separated pipeline produces identical results to monolithic.')\n",
+    "    print(f'\\nTiming: original={timings.get(\"original_sec\", \"?\"):.1f}s, '\n",
+    "          f'separated={timings.get(\"separated_sec\", \"?\"):.1f}s')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- add standalone pipeline modules under `separation/` for preprocessing, motion correction, source detection, and component filtering
- add standalone tests for each module plus a cross-module chaining test
- add `separation/tools/run_separation_judgement.py` and `separation_judgement.ipynb` for monolithic-vs-separated parity judgement
- patch environment and toy-data compatibility:
  - pin `markupsafe=2.0.1` in `environment.yml`
  - update `minian/test/toy_data.py` for `estimate_motion`, `shift_dim`, and current `save_minian` API

## Validation
- attempted:
  - `pytest -q separation/component_filtering/tests/test_component_filtering_standalone.py separation/preprocessing/tests/test_preprocessing_standalone.py separation/motion_correction/tests/test_motion_correction_standalone.py separation/source_detection/tests/test_source_detection_standalone.py`
- blocked in this environment by missing dependency: `ModuleNotFoundError: No module named 'ffmpeg'`

