### PR TITLE
refactor: move video I/O to minian.io (part of #309)

### DIFF
--- a/minian/io.py
+++ b/minian/io.py
@@ -1,0 +1,371 @@
+"""Video and movie file I/O for MiniAn."""
+
+import functools as fct
+import os
+import re
+import shutil
+import sys
+from collections.abc import Callable
+from uuid import uuid4
+
+import cv2
+import dask as da
+import dask.array as darr
+import ffmpeg
+import numpy as np
+import skvideo.io
+import xarray as xr
+from natsort import natsorted
+from tifffile import TiffFile, imread
+
+from .utilities import custom_arr_optimize
+
+if sys.version_info < (3, 13):
+    from typing_extensions import deprecated
+else:
+    from warnings import deprecated
+
+
+def _ensure_ffmpeg() -> None:
+    """Require ``ffmpeg`` and ``ffprobe`` on ``PATH`` before video I/O."""
+    for name in ("ffmpeg", "ffprobe"):
+        if shutil.which(name) is None:
+            raise RuntimeError(
+                f"{name!r} not found on PATH. MiniAn needs FFmpeg for "
+                "AVI/MKV ingest and MP4 export. Install FFmpeg and ensure it "
+                "is on PATH (https://ffmpeg.org/download.html)."
+            )
+
+
+def load_videos(
+    vpath: str,
+    pattern=r"msCam[0-9]+\.avi$",
+    dtype: str | type = np.float64,
+    downsample: dict | None = None,
+    downsample_strategy="subset",
+    post_process: Callable | None = None,
+) -> xr.DataArray:
+    """
+    Load multiple videos in a folder and return a `xr.DataArray`.
+
+    Load videos from the folder specified in `vpath` and according to the regex
+    `pattern`, then concatenate them together and return a `xr.DataArray`
+    representation of the concatenated videos. The videos are sorted by
+    filenames with :func:`natsort.natsorted` before concatenation. Optionally
+    the data can be downsampled, and the user can pass in a custom callable to
+    post-process the result.
+
+    Parameters
+    ----------
+    vpath : str
+        The path containing the videos to load.
+    pattern : regexp, optional
+        The regexp matching the filenames of the videso. By default
+        `r"msCam[0-9]+\.avi$"`, which can be interpreted as filenames starting
+        with "msCam" followed by at least a number, and then followed by ".avi".
+    dtype : Union[str, type], optional
+        Datatype of the resulting DataArray, by default `np.float64`.
+    downsample : dict, optional
+        A dictionary mapping dimension names to an integer downsampling factor.
+        The dimension names should be one of "height", "width" or "frame". By
+        default `None`.
+    downsample_strategy : str, optional
+        How the downsampling should be done. Only used if `downsample` is not
+        `None`. Either `"subset"` where data points are taken at an interval
+        specified in `downsample`, or `"mean"` where mean will be taken over
+        data within each interval. By default `"subset"`.
+    post_process : Callable, optional
+        An user-supplied custom function to post-process the resulting array.
+        Four arguments will be passed to the function: the resulting DataArray
+        `varr`, the input path `vpath`, the list of matched video filenames
+        `vlist`, and the list of DataArray before concatenation `varr_list`. The
+        function should output another valide DataArray. In other words, the
+        function should have signature `f(varr: xr.DataArray, vpath: str, vlist:
+        list[str], varr_list: list[xr.DataArray]) -> xr.DataArray`. By default
+        `None`
+
+    Returns
+    -------
+    varr : xr.DataArray
+        The resulting array representation of the input movie. Should have
+        dimensions ("frame", "height", "width").
+
+    Raises
+    ------
+    FileNotFoundError
+        if no files under `vpath` match the pattern `pattern`
+    ValueError
+        if the matched files does not have extension ".avi", ".mkv" or ".tif"
+    NotImplementedError
+        if `downsample_strategy` is not "subset" or "mean"
+    """
+    vpath = os.path.normpath(vpath)
+    vlist = natsorted(
+        [vpath + os.sep + v for v in os.listdir(vpath) if re.search(pattern, v)]
+    )
+    if not vlist:
+        raise FileNotFoundError(
+            f"No data with pattern {pattern}"
+            f" found in the specified folder {vpath}"
+        )
+    print(f"loading {len(vlist)} videos in folder {vpath}")
+
+    file_extension = os.path.splitext(vlist[0])[1]
+    if file_extension in (".avi", ".mkv"):
+        movie_load_func = _load_avi_lazy
+    elif file_extension == ".tif":
+        movie_load_func = _load_tif_lazy
+    else:
+        raise ValueError("Extension not supported.")
+
+    varr_list = [movie_load_func(v) for v in vlist]
+    varr = darr.concatenate(varr_list, axis=0)
+    varr = xr.DataArray(
+        varr,
+        dims=["frame", "height", "width"],
+        coords=dict(
+            frame=np.arange(varr.shape[0]),
+            height=np.arange(varr.shape[1]),
+            width=np.arange(varr.shape[2]),
+        ),
+    )
+    if dtype:
+        varr = varr.astype(dtype)
+    if downsample:
+        if downsample_strategy == "mean":
+            varr = varr.coarsen(**downsample, boundary="trim", coord_func="min").mean()
+        elif downsample_strategy == "subset":
+            varr = varr.isel(**{d: slice(None, None, w) for d, w in downsample.items()})
+        else:
+            raise NotImplementedError("unrecognized downsampling strategy")
+    varr = varr.rename("fluorescence")
+    if post_process:
+        varr = post_process(varr, vpath, vlist, varr_list)
+    arr_opt = fct.partial(custom_arr_optimize, keep_patterns=["^load_avi_ffmpeg"])
+    with da.config.set(array_optimize=arr_opt):
+        varr = da.optimize(varr)[0]
+    return varr
+
+
+def _load_tif_lazy(fname: str) -> darr.array:
+    """Lazy load a tif stack of images."""
+    data = TiffFile(fname)
+    f = len(data.pages)
+
+    fmread = da.delayed(_load_tif_perframe)
+    flist = [fmread(fname, i) for i in range(f)]
+
+    sample = flist[0].compute()
+    arr = [
+        da.array.from_delayed(fm, dtype=sample.dtype, shape=sample.shape)
+        for fm in flist
+    ]
+    return da.array.stack(arr, axis=0)
+
+
+def _load_tif_perframe(fname: str, fid: int) -> np.ndarray:
+    """Load a single image from a tif stack."""
+    return imread(fname, key=fid)
+
+
+@deprecated(
+    "load_avi_lazy_framewise is deprecated in v1.3.0 and will be removed in "
+    "v2.0.0. Use load_videos (ffmpeg-based lazy loading) instead."
+)
+def load_avi_lazy_framewise(fname: str) -> darr.array:
+    cap = cv2.VideoCapture(fname)
+    f = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    fmread = da.delayed(load_avi_perframe)
+    flist = [fmread(fname, i) for i in range(f)]
+    sample = flist[0].compute()
+    arr = [
+        da.array.from_delayed(fm, dtype=sample.dtype, shape=sample.shape)
+        for fm in flist
+    ]
+    return da.array.stack(arr, axis=0)
+
+
+def _load_avi_lazy(fname: str) -> darr.array:
+    """
+    Lazy load an avi video.
+
+    This function construct a single delayed task for loading the video as a
+    whole.
+
+    Parameters
+    ----------
+    fname : str
+        The filename of the video to load.
+
+    Returns
+    -------
+    arr : darr.array
+        The array representation of the video.
+    """
+    _ensure_ffmpeg()
+    probe = ffmpeg.probe(fname)
+    video_info = next(s for s in probe["streams"] if s["codec_type"] == "video")
+    w = int(video_info["width"])
+    h = int(video_info["height"])
+    f = int(video_info["nb_frames"])
+    return da.array.from_delayed(
+        da.delayed(load_avi_ffmpeg)(fname, h, w, f), dtype=np.uint8, shape=(f, h, w)
+    )
+
+
+def load_avi_ffmpeg(fname: str, h: int, w: int, f: int) -> np.ndarray:
+    """
+    Load an avi video using `ffmpeg`.
+
+    This function directly invoke `ffmpeg` using the `python-ffmpeg` wrapper and
+    retrieve the data from buffer.
+
+    Parameters
+    ----------
+    fname : str
+        The filename of the video to load.
+    h : int
+        The height of the video.
+    w : int
+        The width of the video.
+    f : int
+        The number of frames in the video.
+
+    Returns
+    -------
+    arr : np.ndarray
+        The resulting array. Has shape (`f`, `h`, `w`).
+    """
+    out_bytes, err = (
+        ffmpeg.input(fname)
+        .video.output("pipe:", format="rawvideo", pix_fmt="gray")
+        .run(capture_stdout=True)
+    )
+    return np.frombuffer(out_bytes, np.uint8).reshape(f, h, w)
+
+
+@deprecated(
+    "load_avi_perframe is deprecated in v1.3.0 and will be removed in v2.0.0. "
+    "Use load_videos (ffmpeg-based lazy loading) instead."
+)
+def load_avi_perframe(fname: str, fid: int) -> np.ndarray:
+    cap = cv2.VideoCapture(fname)
+    h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    cap.set(cv2.CAP_PROP_POS_FRAMES, fid)
+    ret, fm = cap.read()
+    if ret:
+        return np.flip(cv2.cvtColor(fm, cv2.COLOR_RGB2GRAY), axis=0)
+    else:
+        print(f"frame read failed for frame {fid}")
+        return np.zeros((h, w))
+
+
+@deprecated(
+    "write_vid_blk is deprecated in v1.3.0 and will be removed in v2.0.0. "
+    "Use write_video instead."
+)
+def write_vid_blk(arr, vpath, options):
+    _ensure_ffmpeg()
+    uid = uuid4()
+    vname = f"{uid}.mp4"
+    fpath = os.path.join(vpath, vname)
+    if len(arr.shape) == 2:
+        arr = np.expand_dims(arr, axis=0)
+    writer = skvideo.io.FFmpegWriter(
+        fpath, outputdict={"-" + k: v for k, v in options.items()}
+    )
+    for fm in arr:
+        writer.writeFrame(fm)
+    writer.close()
+    return fpath
+
+
+def write_video(
+    arr: xr.DataArray,
+    vname: str | None = None,
+    vpath: str | None = ".",
+    norm=True,
+    options={"crf": "18", "preset": "ultrafast"},
+) -> str:
+    """
+    Write a video from a movie array using `python-ffmpeg`.
+
+    Parameters
+    ----------
+    arr : xr.DataArray
+        Input movie array. Should have dimensions: ("frame", "height", "width")
+        and should only be chunked along the "frame" dimension.
+    vname : str, optional
+        The name of output video. If `None` then a random one will be generated
+        using :func:`uuid4.uuid`. By default `None`.
+    vpath : str, optional
+        The path to the folder containing the video. By default `"."`.
+    norm : bool, optional
+        Whether to normalize the values of the input array such that they span
+        the full pixel depth range (0, 255). By default `True`.
+    options : dict, optional
+        Optional output arguments passed to `ffmpeg`. By default `{"crf": "18",
+        "preset": "ultrafast"}`.
+
+    Returns
+    -------
+    fname : str
+        The absolute path to the video file.
+
+    See Also
+    --------
+    ffmpeg.output
+    """
+    _ensure_ffmpeg()
+    if not vname:
+        vname = f"{uuid4()}.mp4"
+    fname = os.path.join(vpath, vname)
+    if norm:
+        arr_opt = fct.partial(
+            custom_arr_optimize, rename_dict={"rechunk": "merge_restricted"}
+        )
+        with da.config.set(array_optimize=arr_opt):
+            arr = arr.astype(np.float32)
+            arr_max = arr.max().compute().values
+            arr_min = arr.min().compute().values
+        den = arr_max - arr_min
+        arr -= arr_min
+        arr /= den
+        arr *= 255
+    arr = arr.clip(0, 255).astype(np.uint8)
+    w, h = arr.sizes["width"], arr.sizes["height"]
+    process = (
+        ffmpeg.input("pipe:", format="rawvideo", pix_fmt="gray", s=f"{w}x{h}")
+        .filter("pad", int(np.ceil(w / 2) * 2), int(np.ceil(h / 2) * 2))
+        .output(fname, pix_fmt="yuv420p", vcodec="libx264", r=30, **options)
+        .overwrite_output()
+        .run_async(pipe_stdin=True)
+    )
+    for blk in arr.data.blocks:
+        process.stdin.write(np.array(blk).tobytes())
+    process.stdin.close()
+    process.wait()
+    return fname
+
+
+@deprecated(
+    "concat_video_recursive is deprecated in v1.3.0 and will be removed in "
+    "v2.0.0."
+)
+def concat_video_recursive(vlist, vname=None):
+    _ensure_ffmpeg()
+    if not len(vlist) > 1:
+        return vlist[0]
+    if len(vlist) > 256:
+        vlist = np.array_split(vlist, 256)
+        vlist = [concat_video_recursive(list(v)) for v in vlist]
+    vpath = os.path.dirname(vlist[0])
+    streams = [ffmpeg.input(p) for p in vlist]
+    if vname is None:
+        vname = f"{uuid4()}.mp4"
+    fpath = os.path.join(vpath, vname)
+    ffmpeg.concat(*streams).output(fpath).run(overwrite_output=True)
+    for vp in vlist:
+        os.remove(vp)
+    return fpath

--- a/minian/test/test_pre_processing.py
+++ b/minian/test/test_pre_processing.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 import holoviews as hv
 
-from ..utilities import load_videos
+from ..io import load_videos
 from ..preprocessing import denoise, remove_background, stripe_correction
 
 dpath = "./demo_movies"

--- a/minian/utilities.py
+++ b/minian/utilities.py
@@ -15,7 +15,6 @@ import _operator
 import cv2
 import dask as da
 import dask.array as darr
-import ffmpeg
 import numpy as np
 import pandas as pd
 import rechunker
@@ -27,11 +26,9 @@ from dask.optimization import cull, fuse, inline, inline_functions
 from dask.utils import ensure_dict
 from distributed.diagnostics.plugin import SchedulerPlugin
 from distributed.scheduler import SchedulerState, cast
-from natsort import natsorted
 from scipy.ndimage import median_filter
 from scipy.sparse import csc_matrix
 from scipy.sparse.linalg import lsqr
-from tifffile import TiffFile, imread
 
 # dask >=2025 (a hard floor in pyproject) ships the TaskSpec optimizer, which
 # does its own graph optimisation. The legacy `fuse` / `inline_pattern` hooks
@@ -39,258 +36,45 @@ from tifffile import TiffFile, imread
 # `custom_arr_optimize` / `custom_delay_optimize` below.
 from dask.array.optimization import fuse_linear_task_spec
 
+_IO_DEPRECATED_NAMES = frozenset(
+    {
+        "load_avi_lazy_framewise",
+        "load_avi_perframe",
+    }
+)
 
-def ensure_ffmpeg() -> None:
-    """Require ``ffmpeg`` and ``ffprobe`` on ``PATH`` before video I/O."""
-    for name in ("ffmpeg", "ffprobe"):
-        if shutil.which(name) is None:
-            raise RuntimeError(
-                f"{name!r} not found on PATH. MiniAn needs FFmpeg for "
-                "AVI/MKV ingest and MP4 export. Install FFmpeg and ensure it "
-                "is on PATH (https://ffmpeg.org/download.html)."
-            )
+_IO_MOVED_NAMES = frozenset(
+    {
+        "ensure_ffmpeg",
+        "load_avi_ffmpeg",
+        "load_avi_lazy",
+        "load_tif_lazy",
+        "load_tif_perframe",
+        "load_videos",
+    }
+)
 
 
-def load_videos(
-    vpath: str,
-    pattern=r"msCam[0-9]+\.avi$",
-    dtype: str | type = np.float64,
-    downsample: dict | None = None,
-    downsample_strategy="subset",
-    post_process: Callable | None = None,
-) -> xr.DataArray:
-    """
-    Load multiple videos in a folder and return a `xr.DataArray`.
-
-    Load videos from the folder specified in `vpath` and according to the regex
-    `pattern`, then concatenate them together and return a `xr.DataArray`
-    representation of the concatenated videos. The videos are sorted by
-    filenames with :func:`natsort.natsorted` before concatenation. Optionally
-    the data can be downsampled, and the user can pass in a custom callable to
-    post-process the result.
-
-    Parameters
-    ----------
-    vpath : str
-        The path containing the videos to load.
-    pattern : regexp, optional
-        The regexp matching the filenames of the videso. By default
-        `r"msCam[0-9]+\.avi$"`, which can be interpreted as filenames starting
-        with "msCam" followed by at least a number, and then followed by ".avi".
-    dtype : Union[str, type], optional
-        Datatype of the resulting DataArray, by default `np.float64`.
-    downsample : dict, optional
-        A dictionary mapping dimension names to an integer downsampling factor.
-        The dimension names should be one of "height", "width" or "frame". By
-        default `None`.
-    downsample_strategy : str, optional
-        How the downsampling should be done. Only used if `downsample` is not
-        `None`. Either `"subset"` where data points are taken at an interval
-        specified in `downsample`, or `"mean"` where mean will be taken over
-        data within each interval. By default `"subset"`.
-    post_process : Callable, optional
-        An user-supplied custom function to post-process the resulting array.
-        Four arguments will be passed to the function: the resulting DataArray
-        `varr`, the input path `vpath`, the list of matched video filenames
-        `vlist`, and the list of DataArray before concatenation `varr_list`. The
-        function should output another valide DataArray. In other words, the
-        function should have signature `f(varr: xr.DataArray, vpath: str, vlist:
-        list[str], varr_list: list[xr.DataArray]) -> xr.DataArray`. By default
-        `None`
-
-    Returns
-    -------
-    varr : xr.DataArray
-        The resulting array representation of the input movie. Should have
-        dimensions ("frame", "height", "width").
-
-    Raises
-    ------
-    FileNotFoundError
-        if no files under `vpath` match the pattern `pattern`
-    ValueError
-        if the matched files does not have extension ".avi", ".mkv" or ".tif"
-    NotImplementedError
-        if `downsample_strategy` is not "subset" or "mean"
-    """
-    vpath = os.path.normpath(vpath)
-    vlist = natsorted(
-        [vpath + os.sep + v for v in os.listdir(vpath) if re.search(pattern, v)]
-    )
-    if not vlist:
-        raise FileNotFoundError(
-            f"No data with pattern {pattern}"
-            f" found in the specified folder {vpath}"
+def __getattr__(name: str):
+    if name in _IO_MOVED_NAMES | _IO_DEPRECATED_NAMES:
+        warnings.warn(
+            f"Importing {name!r} from minian.utilities is deprecated and will be "
+            "removed in v2.0.0. Import from minian.io instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-    print(f"loading {len(vlist)} videos in folder {vpath}")
+        from . import io
 
-    file_extension = os.path.splitext(vlist[0])[1]
-    if file_extension in (".avi", ".mkv"):
-        movie_load_func = load_avi_lazy
-    elif file_extension == ".tif":
-        movie_load_func = load_tif_lazy
-    else:
-        raise ValueError("Extension not supported.")
-
-    varr_list = [movie_load_func(v) for v in vlist]
-    varr = darr.concatenate(varr_list, axis=0)
-    varr = xr.DataArray(
-        varr,
-        dims=["frame", "height", "width"],
-        coords=dict(
-            frame=np.arange(varr.shape[0]),
-            height=np.arange(varr.shape[1]),
-            width=np.arange(varr.shape[2]),
-        ),
-    )
-    if dtype:
-        varr = varr.astype(dtype)
-    if downsample:
-        if downsample_strategy == "mean":
-            varr = varr.coarsen(**downsample, boundary="trim", coord_func="min").mean()
-        elif downsample_strategy == "subset":
-            varr = varr.isel(**{d: slice(None, None, w) for d, w in downsample.items()})
-        else:
-            raise NotImplementedError("unrecognized downsampling strategy")
-    varr = varr.rename("fluorescence")
-    if post_process:
-        varr = post_process(varr, vpath, vlist, varr_list)
-    arr_opt = fct.partial(custom_arr_optimize, keep_patterns=["^load_avi_ffmpeg"])
-    with da.config.set(array_optimize=arr_opt):
-        varr = da.optimize(varr)[0]
-    return varr
-
-
-def load_tif_lazy(fname: str) -> darr.array:
-    """
-    Lazy load a tif stack of images.
-
-    Parameters
-    ----------
-    fname : str
-        The filename of the tif stack to load.
-
-    Returns
-    -------
-    arr : darr.array
-        Resulting dask array representation of the tif stack.
-    """
-    data = TiffFile(fname)
-    f = len(data.pages)
-
-    fmread = da.delayed(load_tif_perframe)
-    flist = [fmread(fname, i) for i in range(f)]
-
-    sample = flist[0].compute()
-    arr = [
-        da.array.from_delayed(fm, dtype=sample.dtype, shape=sample.shape)
-        for fm in flist
-    ]
-    return da.array.stack(arr, axis=0)
-
-
-def load_tif_perframe(fname: str, fid: int) -> np.ndarray:
-    """
-    Load a single image from a tif stack.
-
-    Parameters
-    ----------
-    fname : str
-        The filename of the tif stack.
-    fid : int
-        The index of the image to load.
-
-    Returns
-    -------
-    arr : np.ndarray
-        Array representation of the image.
-    """
-    return imread(fname, key=fid)
-
-
-def load_avi_lazy_framewise(fname: str) -> darr.array:
-    cap = cv2.VideoCapture(fname)
-    f = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-    fmread = da.delayed(load_avi_perframe)
-    flist = [fmread(fname, i) for i in range(f)]
-    sample = flist[0].compute()
-    arr = [
-        da.array.from_delayed(fm, dtype=sample.dtype, shape=sample.shape)
-        for fm in flist
-    ]
-    return da.array.stack(arr, axis=0)
-
-
-def load_avi_lazy(fname: str) -> darr.array:
-    """
-    Lazy load an avi video.
-
-    This function construct a single delayed task for loading the video as a
-    whole.
-
-    Parameters
-    ----------
-    fname : str
-        The filename of the video to load.
-
-    Returns
-    -------
-    arr : darr.array
-        The array representation of the video.
-    """
-    ensure_ffmpeg()
-    probe = ffmpeg.probe(fname)
-    video_info = next(s for s in probe["streams"] if s["codec_type"] == "video")
-    w = int(video_info["width"])
-    h = int(video_info["height"])
-    f = int(video_info["nb_frames"])
-    return da.array.from_delayed(
-        da.delayed(load_avi_ffmpeg)(fname, h, w, f), dtype=np.uint8, shape=(f, h, w)
-    )
-
-
-def load_avi_ffmpeg(fname: str, h: int, w: int, f: int) -> np.ndarray:
-    """
-    Load an avi video using `ffmpeg`.
-
-    This function directly invoke `ffmpeg` using the `python-ffmpeg` wrapper and
-    retrieve the data from buffer.
-
-    Parameters
-    ----------
-    fname : str
-        The filename of the video to load.
-    h : int
-        The height of the video.
-    w : int
-        The width of the video.
-    f : int
-        The number of frames in the video.
-
-    Returns
-    -------
-    arr : np.ndarray
-        The resulting array. Has shape (`f`, `h`, `w`).
-    """
-    out_bytes, err = (
-        ffmpeg.input(fname)
-        .video.output("pipe:", format="rawvideo", pix_fmt="gray")
-        .run(capture_stdout=True)
-    )
-    return np.frombuffer(out_bytes, np.uint8).reshape(f, h, w)
-
-
-def load_avi_perframe(fname: str, fid: int) -> np.ndarray:
-    cap = cv2.VideoCapture(fname)
-    h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-    cap.set(cv2.CAP_PROP_POS_FRAMES, fid)
-    ret, fm = cap.read()
-    if ret:
-        return np.flip(cv2.cvtColor(fm, cv2.COLOR_RGB2GRAY), axis=0)
-    else:
-        print(f"frame read failed for frame {fid}")
-        return np.zeros((h, w))
+        if name == "ensure_ffmpeg":
+            return io._ensure_ffmpeg
+        if name == "load_avi_lazy":
+            return io._load_avi_lazy
+        if name == "load_tif_lazy":
+            return io._load_tif_lazy
+        if name == "load_tif_perframe":
+            return io._load_tif_perframe
+        return getattr(io, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def open_minian(

--- a/minian/visualization.py
+++ b/minian/visualization.py
@@ -1,6 +1,7 @@
 import functools as fct
 import itertools as itt
 import os
+import warnings
 from collections import OrderedDict
 from typing import Optional, Union
 from collections.abc import Callable
@@ -10,7 +11,6 @@ import colorcet as cc
 import cv2
 import dask
 import dask.array as da
-import ffmpeg
 import holoviews as hv
 import numpy as np
 import pandas as pd
@@ -18,7 +18,6 @@ import panel as pn
 import param
 import scipy.sparse as scisps
 import sklearn.mixture
-import skvideo.io
 import xarray as xr
 from bokeh.palettes import Category10_10, Viridis256
 from dask.diagnostics import ProgressBar
@@ -42,7 +41,24 @@ from scipy.spatial import cKDTree
 
 from .cnmf import compute_AtC
 from .motion_correction import apply_shifts
-from .utilities import custom_arr_optimize, ensure_ffmpeg, rechunk_like
+from .io import write_video
+from .utilities import custom_arr_optimize, rechunk_like
+
+_VIZ_IO_DEPRECATED_NAMES = frozenset({"concat_video_recursive", "write_vid_blk"})
+
+
+def __getattr__(name: str):
+    if name in _VIZ_IO_DEPRECATED_NAMES:
+        warnings.warn(
+            f"Importing {name!r} from minian.visualization is deprecated and will be "
+            "removed in v2.0.0. Import from minian.io instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from . import io
+
+        return getattr(io, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class VArrayViewer:
@@ -1197,108 +1213,6 @@ class AlignViewer:
         return pn.layout.Row(
             self.plot, pn.layout.Column(self.wgt_meta, self.wgt_rgb, self.wgt_opt)
         )
-
-
-def write_vid_blk(arr, vpath, options):
-    ensure_ffmpeg()
-    uid = uuid4()
-    vname = f"{uid}.mp4"
-    fpath = os.path.join(vpath, vname)
-    if len(arr.shape) == 2:
-        arr = np.expand_dims(arr, axis=0)
-    writer = skvideo.io.FFmpegWriter(
-        fpath, outputdict={"-" + k: v for k, v in options.items()}
-    )
-    for fm in arr:
-        writer.writeFrame(fm)
-    writer.close()
-    return fpath
-
-
-def write_video(
-    arr: xr.DataArray,
-    vname: str | None = None,
-    vpath: str | None = ".",
-    norm=True,
-    options={"crf": "18", "preset": "ultrafast"},
-) -> str:
-    """
-    Write a video from a movie array using `python-ffmpeg`.
-
-    Parameters
-    ----------
-    arr : xr.DataArray
-        Input movie array. Should have dimensions: ("frame", "height", "width")
-        and should only be chunked along the "frame" dimension.
-    vname : str, optional
-        The name of output video. If `None` then a random one will be generated
-        using :func:`uuid4.uuid`. By default `None`.
-    vpath : str, optional
-        The path to the folder containing the video. By default `"."`.
-    norm : bool, optional
-        Whether to normalize the values of the input array such that they span
-        the full pixel depth range (0, 255). By default `True`.
-    options : dict, optional
-        Optional output arguments passed to `ffmpeg`. By default `{"crf": "18",
-        "preset": "ultrafast"}`.
-
-    Returns
-    -------
-    fname : str
-        The absolute path to the video file.
-
-    See Also
-    --------
-    ffmpeg.output
-    """
-    ensure_ffmpeg()
-    if not vname:
-        vname = f"{uuid4()}.mp4"
-    fname = os.path.join(vpath, vname)
-    if norm:
-        arr_opt = fct.partial(
-            custom_arr_optimize, rename_dict={"rechunk": "merge_restricted"}
-        )
-        with dask.config.set(array_optimize=arr_opt):
-            arr = arr.astype(np.float32)
-            arr_max = arr.max().compute().values
-            arr_min = arr.min().compute().values
-        den = arr_max - arr_min
-        arr -= arr_min
-        arr /= den
-        arr *= 255
-    arr = arr.clip(0, 255).astype(np.uint8)
-    w, h = arr.sizes["width"], arr.sizes["height"]
-    process = (
-        ffmpeg.input("pipe:", format="rawvideo", pix_fmt="gray", s=f"{w}x{h}")
-        .filter("pad", int(np.ceil(w / 2) * 2), int(np.ceil(h / 2) * 2))
-        .output(fname, pix_fmt="yuv420p", vcodec="libx264", r=30, **options)
-        .overwrite_output()
-        .run_async(pipe_stdin=True)
-    )
-    for blk in arr.data.blocks:
-        process.stdin.write(np.array(blk).tobytes())
-    process.stdin.close()
-    process.wait()
-    return fname
-
-
-def concat_video_recursive(vlist, vname=None):
-    ensure_ffmpeg()
-    if not len(vlist) > 1:
-        return vlist[0]
-    if len(vlist) > 256:
-        vlist = np.array_split(vlist, 256)
-        vlist = [concat_video_recursive(list(v)) for v in vlist]
-    vpath = os.path.dirname(vlist[0])
-    streams = [ffmpeg.input(p) for p in vlist]
-    if vname is None:
-        vname = f"{uuid4()}.mp4"
-    fpath = os.path.join(vpath, vname)
-    ffmpeg.concat(*streams).output(fpath).run(overwrite_output=True)
-    for vp in vlist:
-        os.remove(vp)
-    return fpath
 
 
 def generate_videos(

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "numba", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:fff2645dc4aa7fc886386245ce9ca254c6e86a4509909fc7b95513a9f9d86c76"
+content_hash = "sha256:5c367f9fc42884a360d8675179d9d8192ba243f8499af6b5f93f25115d911fc8"
 
 [[metadata.targets]]
 requires_python = ">=3.10,<3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "sparse>=0.11.2",
     "statsmodels>=0.11.1",
     "tifffile",
+    "typing_extensions>=4.0",
     "xarray>=0.17.0",
     "zarr",
 ]


### PR DESCRIPTION
Part of #309

## Summary

Implements [@sneakers-the-rat's step 1](https://github.com/miniscope/minian/issues/309#issuecomment): move video/movie file I/O out of the god modules into a dedicated top-level **`minian.io`** module. This PR is **move-only / behavior-neutral** — no `H264OutputOptions` refactor, no change to ffmpeg kwargs in `write_video`.

- Add `minian/io.py` with `load_videos`, `write_video`, `load_avi_ffmpeg`, and private helpers (`_ensure_ffmpeg`, `_load_avi_lazy`, `_load_tif_lazy`, `_load_tif_perframe`)
- Keep **`load_avi_ffmpeg`** name unchanged (dask graph / `TaskAnnotation` contract)
- Deprecate (do not delete) legacy helpers with PEP 702 `@deprecated`: `load_avi_lazy_framewise`, `load_avi_perframe`, `write_vid_blk`, `concat_video_recursive`
- `minian.utilities`: scipy-style `__getattr__` shim + `DeprecationWarning` for symbols that moved to `minian.io`
- `minian.visualization`: keep `generate_videos`; re-export `write_video` for backward compat; shim deprecated imports of `write_vid_blk` / `concat_video_recursive`
- Add explicit `typing_extensions` dependency (for `@deprecated` on Python <3.13)

## Compatibility

| Old import | New canonical import | Notes |
|------------|----------------------|-------|
| `from minian.utilities import load_videos` | `from minian.io import load_videos` | Shim warns, still works |
| `from minian.utilities import ensure_ffmpeg` | — | Shim maps to private `_ensure_ffmpeg` |
| `from minian.visualization import write_video` | `from minian.io import write_video` | Re-export unchanged |
| `from minian.visualization import write_vid_blk` | `from minian.io import write_vid_blk` | Deprecated |

## Out of scope (follow-up PRs on #309)

- Split remaining `utilities.py` into submodules (`dataset`, `dask_opt`, `chunking`, `signal`)
- `H264OutputOptions` / shared ffmpeg output builder
- `visualization/` package split

## Test plan

- [x] `pdm run python -m pytest minian/test/test_pre_processing.py --no-cov`
- [x] `pdm run ruff check minian/io.py minian/utilities.py minian/visualization.py`
- [x] Manual: `from minian.utilities import load_videos` emits `DeprecationWarning` and returns same object as `minian.io.load_videos`

Made with [Cursor](https://cursor.com)