### PR TITLE
fix(notebooks): gate cross-reg interactive cells on MINIAN_INTERACTIVE

### DIFF
--- a/minian/notebooks/cross_registration/cross-registration.ipynb
+++ b/minian/notebooks/cross_registration/cross-registration.ipynb
@@ -83,7 +83,11 @@
    "outputs": [],
    "source": [
     "param_dist = 5\n",
-    "output_size = 100"
+    "output_size = 100\n",
+    "# `interactive` gates the interactive/visualization cells, mirroring pipeline.ipynb.\n",
+    "# The test suite sets MINIAN_INTERACTIVE=False so non-interactive batch runs (and CI)\n",
+    "# skip the blocking viewers; leave it unset for the full interactive experience.\n",
+    "interactive = os.getenv(\"MINIAN_INTERACTIVE\", \"True\").lower() == \"true\""
    ]
   },
   {
@@ -219,15 +223,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.output(size=int(output_size * 0.6))\n",
-    "opts_im = {\n",
-    "    'aspect': shiftds.sizes['width'] / shiftds.sizes['height'],\n",
-    "    'frame_width': 500, 'cmap': 'viridis'}\n",
-    "hv_temps = (hv.Dataset(temps).to(hv.Image, kdims=['width', 'height'])\n",
-    "            .opts(**opts_im).layout('session').cols(1))\n",
-    "hv_temps_sh = (hv.Dataset(temps_sh).to(hv.Image, kdims=['width', 'height'])\n",
-    "            .opts(**opts_im).layout('session').cols(1))\n",
-    "display(hv_temps + hv_temps_sh)"
+    "if interactive:\n",
+    "    hv.output(size=int(output_size * 0.6))\n",
+    "    opts_im = {\n",
+    "        'aspect': shiftds.sizes['width'] / shiftds.sizes['height'],\n",
+    "        'frame_width': 500, 'cmap': 'viridis'}\n",
+    "    hv_temps = (hv.Dataset(temps).to(hv.Image, kdims=['width', 'height'])\n",
+    "                .opts(**opts_im).layout('session').cols(1))\n",
+    "    hv_temps_sh = (hv.Dataset(temps_sh).to(hv.Image, kdims=['width', 'height'])\n",
+    "                .opts(**opts_im).layout('session').cols(1))\n",
+    "    display(hv_temps + hv_temps_sh)"
    ]
   },
   {
@@ -250,15 +255,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.output(size=int(output_size * 0.6))\n",
-    "opts_im = {\n",
-    "    'aspect': shiftds.sizes['width'] / shiftds.sizes['height'],\n",
-    "    'frame_width': 500, 'cmap': 'viridis'}\n",
+    "# `window` is consumed downstream (set_window, calculate_centroids), so always compute\n",
+    "# it; only the visualization below is gated on `interactive`.\n",
     "window = shiftds['temps_shifted'].isnull().sum('session')\n",
     "window, _ = xr.broadcast(window, shiftds['temps_shifted'])\n",
-    "hv_wnd = hv.Dataset(window).to(hv.Image, ['width', 'height'])\n",
-    "hv_temps = hv.Dataset(temps_sh).to(hv.Image, ['width', 'height'])\n",
-    "hv_wnd.opts(**opts_im).relabel(\"Window\") + hv_temps.opts(**opts_im).relabel(\"Shifted Templates\")"
+    "if interactive:\n",
+    "    hv.output(size=int(output_size * 0.6))\n",
+    "    opts_im = {\n",
+    "        'aspect': shiftds.sizes['width'] / shiftds.sizes['height'],\n",
+    "        'frame_width': 500, 'cmap': 'viridis'}\n",
+    "    hv_wnd = hv.Dataset(window).to(hv.Image, ['width', 'height'])\n",
+    "    hv_temps = hv.Dataset(temps_sh).to(hv.Image, ['width', 'height'])\n",
+    "    display(hv_wnd.opts(**opts_im).relabel(\"Window\")\n",
+    "            + hv_temps.opts(**opts_im).relabel(\"Shifted Templates\"))"
    ]
   },
   {
@@ -436,9 +445,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.output(size=int(output_size * 0.7))\n",
-    "alnviewer = AlignViewer(minian_ds, cents, mappings_meta_fill, shiftds)\n",
-    "alnviewer.show()"
+    "if interactive:\n",
+    "    hv.output(size=int(output_size * 0.7))\n",
+    "    alnviewer = AlignViewer(minian_ds, cents, mappings_meta_fill, shiftds)\n",
+    "    alnviewer.show()"
    ]
   },
   {


### PR DESCRIPTION
## What

The cross-registration notebook ran its interactive visualizations **unconditionally**, ignoring the `MINIAN_INTERACTIVE` flag that `pipeline.ipynb` already honors. Most importantly it called `alnviewer.show()` (an `AlignViewer`), whose `.show()` can spin up a blocking Bokeh server.

The test suite sets `MINIAN_INTERACTIVE=False` (`conftest.py`), but cross-reg didn't read it, so the viewer executed under `nbconvert` in CI. This is the likely cause of the **intermittent hang on the cross-reg notebook test** (it passed on 8 of 9 matrix configs but stalled to the 6h limit on one).

## Change

Mirror `pipeline.ipynb`:

- Read `interactive = os.getenv("MINIAN_INTERACTIVE", "True").lower() == "true"` in the parameters cell.
- Gate the three visualization cells (template alignment, FOV-overlap window, `AlignViewer`) behind `if interactive:`.
- Keep the `window` computation **ungated** — it's consumed downstream (`set_window`, `calculate_centroids`).

Interactive users get the full experience (default `True`); batch runs and CI skip the blocking viewers.

## Verified

End-to-end with `MINIAN_INTERACTIVE=False` via nbconvert (exit 0); the executed notebook is small (interactive cells skipped). Shipped output-clean. Bare `ruff check` / `ruff format --check` pass (notebooks aren't in ruff's include set).

## Context

Surfaced while debugging #336's CI: cross-reg stalled on ubuntu-3.11. Same class of dependency-update modernization the pipeline notebook already received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview minian start -->
----
📚 Documentation preview 📚: https://minian--338.org.readthedocs.build/en/338/

<!-- readthedocs-preview minian end -->