### PR TITLE
ci: timeout guards for notebook runs + fix cross-reg HDF5 save deadlock

### DIFF
--- a/.github/workflows/testandcov.yml
+++ b/.github/workflows/testandcov.yml
@@ -45,6 +45,10 @@ jobs:
     name: Test and Cov py ${{ matrix.python-version }}, ${{ matrix.os }}
     needs: prefetch-data
     runs-on: ${{ matrix.os }}
+    # Healthy runs finish in ~40-60min. This backstop kills a deadlocked job
+    # (e.g. a hung dask cluster) in minutes instead of the 6h GitHub ceiling,
+    # so a flaky hang frees the runner and reports promptly.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/minian/notebooks/cross_registration/cross-registration.ipynb
+++ b/minian/notebooks/cross_registration/cross-registration.ipynb
@@ -195,13 +195,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "%%time\n",
-    "temps = minian_ds['max_proj'].rename('temps')\n",
-    "shifts = estimate_motion(temps, dim='session').compute().rename('shifts')\n",
-    "temps_sh = apply_transform(temps, shifts).compute().rename('temps_shifted')\n",
-    "shiftds = xr.merge([temps, shifts, temps_sh])"
-   ]
+   "source": "%%time\ntemps = minian_ds['max_proj'].rename('temps')\nshifts = estimate_motion(temps, dim='session').compute().rename('shifts')\ntemps_sh = apply_transform(temps, shifts).compute().rename('temps_shifted')\n# Merge a computed copy of temps so shiftds holds no lazy netCDF-backed arrays.\n# Otherwise the to_netcdf save below reads the source minian.nc files (via the\n# netCDF4 backend) on dask threads while writing shiftds.nc, and HDF5's\n# non-thread-safe C library deadlocks intermittently.\nshiftds = xr.merge([temps.compute(), shifts, temps_sh])"
   },
   {
    "cell_type": "markdown",

--- a/minian/notebooks/cross_registration/cross-registration.ipynb
+++ b/minian/notebooks/cross_registration/cross-registration.ipynb
@@ -195,7 +195,17 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%%time\ntemps = minian_ds['max_proj'].rename('temps')\nshifts = estimate_motion(temps, dim='session').compute().rename('shifts')\ntemps_sh = apply_transform(temps, shifts).compute().rename('temps_shifted')\n# Merge a computed copy of temps so shiftds holds no lazy netCDF-backed arrays.\n# Otherwise the to_netcdf save below reads the source minian.nc files (via the\n# netCDF4 backend) on dask threads while writing shiftds.nc, and HDF5's\n# non-thread-safe C library deadlocks intermittently.\nshiftds = xr.merge([temps.compute(), shifts, temps_sh])"
+   "source": [
+    "%%time\n",
+    "temps = minian_ds['max_proj'].rename('temps')\n",
+    "shifts = estimate_motion(temps, dim='session').compute().rename('shifts')\n",
+    "temps_sh = apply_transform(temps, shifts).compute().rename('temps_shifted')\n",
+    "# Merge a computed copy of temps so shiftds holds no lazy netCDF-backed arrays.\n",
+    "# Otherwise the to_netcdf save below reads the source minian.nc files (via the\n",
+    "# netCDF4 backend) on dask threads while writing shiftds.nc, and HDF5's\n",
+    "# non-thread-safe C library deadlocks intermittently.\n",
+    "shiftds = xr.merge([temps.compute(), shifts, temps_sh])"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/minian/test/_notebook.py
+++ b/minian/test/_notebook.py
@@ -23,7 +23,9 @@ def execute_notebook(relpath: str, output: str) -> Path:
     ``output`` is the output base name (no extension); the executed notebook is
     written to ``artifact/<output>.ipynb`` (the docs build reads it from there).
     ``check=True`` turns a non-zero nbconvert exit (a failed notebook) into a
-    test failure.
+    test failure. The per-cell ``--ExecutePreprocessor.timeout`` bounds a hung
+    cell (e.g. a deadlocked dask cluster) so it surfaces as a failing test with
+    a traceback rather than blocking until CI's wall-clock ceiling.
     """
     ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
     subprocess.run(
@@ -35,6 +37,7 @@ def execute_notebook(relpath: str, output: str) -> Path:
             "--to",
             "notebook",
             "--execute",
+            "--ExecutePreprocessor.timeout=600",
             "--output-dir",
             str(ARTIFACT_DIR),
             "--output",


### PR DESCRIPTION
## Problem

The slow notebook tests execute `pipeline.ipynb` etc., each spinning up a dask `LocalCluster` + distributed `Client`. This intermittently **deadlocks** in CI. Because there was **no timeout anywhere** (no `timeout-minutes`, no nbconvert cell timeout, no `pytest-timeout`), a single hung cell ran until GitHub's **6h ceiling** and got auto-cancelled with zero diagnostic output.

The last three master pushes all hit the 6h wall and were cancelled; CI was healthy (~40-60min) through Jun 17:

| Run | Result |
|-----|--------|
| #338 | cancelled at 6h0m |
| #335 | cancelled at 5h58m |
| #334 (opencv-headless) | cancelled at 6h0m |
| ≤ #331 | ✅ ~40-59min |

Each run a *different* single matrix cell hangs (OS-independent, only one Python at a time), which is the classic signature of a distributed-cluster deadlock.

## Change

Two layered guards so a hang surfaces **quickly with a traceback** instead of burning 6h silently:

- **`--ExecutePreprocessor.timeout=600`** on the nbconvert call (`minian/test/_notebook.py`): a hung cell fails in 10min, pointing at the exact cell.
- **`timeout-minutes: 90`** on the `test-and-coverage` job: backstop for hangs *outside* a cell (cluster teardown, collection). Healthy runs take 40-60min, so this leaves headroom.

This does not fix the underlying deadlock; it makes it **diagnosable**. The first run that hits the hang will now produce a traceback so we can target the root cause (leading theory: dask nanny forking workers while `cv2`'s thread pool is live, plausibly triggered by the #334 opencv-headless switch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview minian start -->
----
📚 Documentation preview 📚: https://minian--339.org.readthedocs.build/en/339/

<!-- readthedocs-preview minian end -->