### PR TITLE
Fix visualize_seeds crash on HoloViews ≥1.16 (size_index/color_index removed)

### DIFF
--- a/minian/visualization.py
+++ b/minian/visualization.py
@@ -1569,15 +1569,16 @@ def visualize_seeds(
     opts_pts = {
         "frame_width": 600,
         "aspect": asp,
-        "size": 8,
+        # HoloViews >=1.16 removed size_index/color_index; map the dimensions
+        # directly instead. size_index="seeds" rendered each point with radius
+        # sqrt(base_size * seeds) where base_size = size**2 = (sqrt(6))**2 = 6
+        # (area scaling, scaling_factor=1), so reproduce it exactly here.
+        "size": (hv.dim("seeds") * 6) ** 0.5,
         "tools": ["hover"],
         "fill_alpha": 0.8,
         "line_alpha": 0,
         "cmap": pt_cmap,
     }
-    # HoloViews >=1.16 removed the size_index/color_index options; map the color
-    # dimension directly instead (the mask column, via pt_cmap) and use a fixed
-    # point size.
     if mask:
         vdims = ["seeds", mask]
         opts_pts["color"] = mask

--- a/minian/visualization.py
+++ b/minian/visualization.py
@@ -1569,15 +1569,18 @@ def visualize_seeds(
     opts_pts = {
         "frame_width": 600,
         "aspect": asp,
-        "size_index": "seeds",
-        "color_index": mask,
+        "size": 8,
         "tools": ["hover"],
         "fill_alpha": 0.8,
         "line_alpha": 0,
         "cmap": pt_cmap,
     }
+    # HoloViews >=1.16 removed the size_index/color_index options; map the color
+    # dimension directly instead (the mask column, via pt_cmap) and use a fixed
+    # point size.
     if mask:
         vdims = ["seeds", mask]
+        opts_pts["color"] = mask
     else:
         vdims = ["seeds"]
         opts_pts["color"] = "white"


### PR DESCRIPTION
## Problem

`visualize_seeds()` crashes on any install that resolves HoloViews >= 1.16:

```
ValueError: Unexpected option 'size_index' for Points type across all extensions. No similar options found.
```

`size_index` and `color_index` were removed from `hv.Points` in HoloViews 1.16. There is no upper bound on HoloViews in `requirements.txt`, so a fresh `pip install` pulls the latest (1.23.0) and `visualize_seeds()` fails immediately. Reported against Minian 2.0.0, HoloViews 1.23.0, Python 3.12.

## Fix

In `visualize_seeds` (`minian/visualization.py`), replace the removed `*_index` style options with their modern dimension-mapping equivalents — **preserving the original rendering**, not just silencing the error:

- `color_index=mask` -> `color = mask` (maps the mask column directly; existing `pt_cmap` still colors filtered-out seeds red).
- `size_index="seeds"` -> `size = (dim("seeds") * 6) ** 0.5`. The old path, with no explicit `size`, rendered each point with radius `sqrt(base_size * seeds)` where `base_size = size**2 = (sqrt(6))**2 = 6` (area scaling, `scaling_factor=1`). This expression reproduces that exactly, so the seed-count size encoding (a seed found as a local max in more chunks shows as a bigger dot) is retained.

## Verification

- Reproduced the exact `ValueError` with the original code on HoloViews 1.23.0 + Minian 2.0.0.
- Confirmed the patched function renders cleanly (`hv.render`, both `mask=None` and `mask="mask_pnr"` paths).
- Confirmed the rendered bokeh glyph sizes are **bit-for-bit identical** to the old `size_index` path across `seeds in {1,2,5,10,25,50,100}` on HoloViews 1.22.1 (which still implements `size_index`), and that the new `size=` expression renders on 1.23.0.

Reported via miniscope/workshop-processing-and-analysis#1.

Generated with Claude Code