### PR TITLE
feat(pipeline-nb): expose rechunker mem_limit as a tunable parameter

### DIFF
--- a/minian/notebooks/pipeline/pipeline.ipynb
+++ b/minian/notebooks/pipeline/pipeline.ipynb
@@ -250,6 +250,12 @@
     "# separate process; modern dask kills any worker that exceeds this. Default\n",
     "# \"4GB\" targets a 16GB laptop with 4 workers; lower it on smaller machines.\n",
     "memory_limit = os.getenv(\"MINIAN_MEM_LIMIT\", \"4GB\")\n",
+    "# rechunk_mem_limit caps RAM per rechunker task in save_minian's on-disk\n",
+    "# rechunk step (used by save_minian calls that pass chunks=), independent of\n",
+    "# the per-worker memory_limit above. rechunker plans its intermediate grid\n",
+    "# against this value, so a small limit forces many tiny copy tasks on large\n",
+    "# arrays like Y_hw_chk. Keep it at or below the per-worker memory_limit.\n",
+    "rechunk_mem_limit = os.getenv(\"MINIAN_RECHUNK_MEM_LIMIT\", \"1GB\")\n",
     "param_save_minian = {\n",
     "    \"dpath\": minian_ds_path,\n",
     "    \"meta_dict\": dict(session=-1, animal=-2),\n",
@@ -1204,7 +1210,7 @@
     "    Y_fm_chk.rename(\"Y_hw_chk\"),\n",
     "    intpath,\n",
     "    overwrite=True,\n",
-    "    chunks={\"frame\": -1, \"height\": chk[\"height\"], \"width\": chk[\"width\"]},\n",
+    "    mem_limit=rechunk_mem_limit, chunks={\"frame\": -1, \"height\": chk[\"height\"], \"width\": chk[\"width\"]},\n",
     ")"
    ]
   },
@@ -2050,7 +2056,7 @@
     "%%time\n",
     "C_init = initC(Y_fm_chk, A_init)\n",
     "C_init = save_minian(\n",
-    "    C_init.rename(\"C_init\"), intpath, overwrite=True, chunks={\"unit_id\": 1, \"frame\": -1}\n",
+    "    C_init.rename(\"C_init\"), intpath, overwrite=True, mem_limit=rechunk_mem_limit, chunks={\"unit_id\": 1, \"frame\": -1}\n",
     ")"
    ]
   },
@@ -2114,7 +2120,7 @@
     "    C.rename(\"C_chk\"),\n",
     "    intpath,\n",
     "    overwrite=True,\n",
-    "    chunks={\"unit_id\": -1, \"frame\": chk[\"frame\"]},\n",
+    "    mem_limit=rechunk_mem_limit, chunks={\"unit_id\": -1, \"frame\": chk[\"frame\"]},\n",
     ")"
    ]
   },
@@ -2704,7 +2710,7 @@
     "    A_new.rename(\"A\"),\n",
     "    intpath,\n",
     "    overwrite=True,\n",
-    "    chunks={\"unit_id\": 1, \"height\": -1, \"width\": -1},\n",
+    "    mem_limit=rechunk_mem_limit, chunks={\"unit_id\": 1, \"height\": -1, \"width\": -1},\n",
     ")\n",
     "b = save_minian(b_new.rename(\"b\"), intpath, overwrite=True)\n",
     "f = save_minian(\n",
@@ -2909,7 +2915,7 @@
     "    compute_trace(Y_fm_chk, A, b, C_chk, f).rename(\"YrA\"),\n",
     "    intpath,\n",
     "    overwrite=True,\n",
-    "    chunks={\"unit_id\": 1, \"frame\": -1},\n",
+    "    mem_limit=rechunk_mem_limit, chunks={\"unit_id\": 1, \"frame\": -1},\n",
     ")"
    ]
   },
@@ -3174,7 +3180,7 @@
     "    C.rename(\"C_chk\"),\n",
     "    intpath,\n",
     "    overwrite=True,\n",
-    "    chunks={\"unit_id\": -1, \"frame\": chk[\"frame\"]},\n",
+    "    mem_limit=rechunk_mem_limit, chunks={\"unit_id\": -1, \"frame\": chk[\"frame\"]},\n",
     ")\n",
     "S = save_minian(\n",
     "    S_new.rename(\"S\").chunk({\"unit_id\": 1, \"frame\": -1}), intpath, overwrite=True\n",
@@ -3304,7 +3310,7 @@
     "    C.rename(\"C_mrg_chk\"),\n",
     "    intpath,\n",
     "    overwrite=True,\n",
-    "    chunks={\"unit_id\": -1, \"frame\": chk[\"frame\"]},\n",
+    "    mem_limit=rechunk_mem_limit, chunks={\"unit_id\": -1, \"frame\": chk[\"frame\"]},\n",
     ")\n",
     "sig = save_minian(sig_mrg.rename(\"sig_mrg\"), intpath, overwrite=True)"
    ]
@@ -3523,7 +3529,7 @@
     "    A_new.rename(\"A\"),\n",
     "    intpath,\n",
     "    overwrite=True,\n",
-    "    chunks={\"unit_id\": 1, \"height\": -1, \"width\": -1},\n",
+    "    mem_limit=rechunk_mem_limit, chunks={\"unit_id\": 1, \"height\": -1, \"width\": -1},\n",
     ")\n",
     "b = save_minian(b_new.rename(\"b\"), intpath, overwrite=True)\n",
     "f = save_minian(\n",
@@ -3654,7 +3660,7 @@
     "    compute_trace(Y_fm_chk, A, b, C_chk, f).rename(\"YrA\"),\n",
     "    intpath,\n",
     "    overwrite=True,\n",
-    "    chunks={\"unit_id\": 1, \"frame\": -1},\n",
+    "    mem_limit=rechunk_mem_limit, chunks={\"unit_id\": 1, \"frame\": -1},\n",
     ")"
    ]
   },
@@ -3818,7 +3824,7 @@
     "    C.rename(\"C_chk\"),\n",
     "    intpath,\n",
     "    overwrite=True,\n",
-    "    chunks={\"unit_id\": -1, \"frame\": chk[\"frame\"]},\n",
+    "    mem_limit=rechunk_mem_limit, chunks={\"unit_id\": -1, \"frame\": chk[\"frame\"]},\n",
     ")\n",
     "S = save_minian(\n",
     "    S_new.rename(\"S\").chunk({\"unit_id\": 1, \"frame\": -1}), intpath, overwrite=True\n",


### PR DESCRIPTION
## What

Expose `save_minian`'s `mem_limit` as a tunable notebook parameter in the demo pipeline.

A new `rechunk_mem_limit` parameter is defined next to `memory_limit` in the params cell and threaded through all 10 `save_minian(..., chunks=...)` calls (the on-disk rechunk path where `mem_limit` actually matters). The 15 in-memory `.chunk(...)` calls are untouched.

```python
rechunk_mem_limit = os.getenv("MINIAN_RECHUNK_MEM_LIMIT", "1GB")
```

## Why

The notebook never surfaced `mem_limit`, so every rechunking save fell back to the function default of `"500MB"`. For a heavy reshuffle like `Y_hw_chk` (`frame=-1` over the full movie), that small per-task budget forces `rechunker` into a very fine intermediate grid: on a 20 min / 20 fps / 600x600 float64 recording this produced ~74k tiny copy tasks crawling along, even though the dask workers had ~10 GB free each.

The worker `memory_limit` does **not** help here: `rechunker` plans its intermediate grid against its own `mem_limit` argument, independent of the cluster config. Raising `mem_limit` (verified: `"8GB"` on a 12 GB-per-worker setup) collapses the task graph and speeds the rechunk up dramatically.

## Default choice

Default stays conservative at `"1GB"` so it is safe under the shipped 4 GB-per-worker config (the limit is per concurrent rechunk task). It is env-overridable so users can tune without editing the cell:

```
MINIAN_RECHUNK_MEM_LIMIT=8GB
```

Keep it at or below the per-worker `memory_limit`.

## Notes

- The library default in `save_minian` itself is unchanged (`"500MB"`); this only makes the notebook tunable.
- The `pipeline_groundtruth` notebook has no `chunks=` saves, so it needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview minian start -->
----
📚 Documentation preview 📚: https://minian--342.org.readthedocs.build/en/342/

<!-- readthedocs-preview minian end -->