### PR TITLE
fix(viz): draw kept seeds on top of filtered ones in visualize_seeds

### DIFF
--- a/minian/test/test_visualization.py
+++ b/minian/test/test_visualization.py
@@ -78,8 +78,6 @@ class TestVisualizeSeeds:
         from ..visualization import visualize_seeds
 
         hv.extension("bokeh")  # .options() resolves against a loaded backend
-        seeds = pd.DataFrame(
-            {"height": [1, 2], "width": [1, 2], "seeds": [5, 6]}
-        )
+        seeds = pd.DataFrame({"height": [1, 2], "width": [1, 2], "seeds": [5, 6]})
         ov = visualize_seeds(self._max_proj(), seeds)
         assert len(ov.traverse(specs=[hv.Points])) == 1

--- a/minian/test/test_visualization.py
+++ b/minian/test/test_visualization.py
@@ -70,6 +70,9 @@ class TestVisualizeSeeds:
         assert top.dimension_values("mask_good").size == 2
         assert bool(top.dimension_values("mask_good").all())  # top = kept seeds
         assert not bool(bottom.dimension_values("mask_good").any())  # bottom = rejected
+        # header reports the true/false counts
+        title = hv.Store.lookup_options("bokeh", ov, "plot").kwargs.get("title")
+        assert title == "mask_good: 2 true (white), 2 false (red)"
 
     def test_unmasked_returns_single_points_layer(self):
         import holoviews as hv
@@ -81,3 +84,5 @@ class TestVisualizeSeeds:
         seeds = pd.DataFrame({"height": [1, 2], "width": [1, 2], "seeds": [5, 6]})
         ov = visualize_seeds(self._max_proj(), seeds)
         assert len(ov.traverse(specs=[hv.Points])) == 1
+        title = hv.Store.lookup_options("bokeh", ov, "plot").kwargs.get("title")
+        assert title == "seeds: 2 total"

--- a/minian/test/test_visualization.py
+++ b/minian/test/test_visualization.py
@@ -6,6 +6,15 @@ import scipy.sparse
 import xarray as xr
 
 
+def _max_proj(n: int = 10) -> xr.DataArray:
+    """A blank ``(height, width)`` max projection for seeding the viz helpers."""
+    return xr.DataArray(
+        np.zeros((n, n), dtype="float32"),
+        dims=("height", "width"),
+        coords={"height": np.arange(n), "width": np.arange(n)},
+    )
+
+
 class TestVisualizeSpatialPartition:
     """The visualization layer is mostly covered by notebook execution in
     test_pipeline.py; here we just pin the explicit contract violation
@@ -18,11 +27,7 @@ class TestVisualizeSpatialPartition:
         # file needs.
         from ..visualization import visualize_spatial_partition
 
-        max_proj = xr.DataArray(
-            np.zeros((10, 10), dtype="float32"),
-            dims=("height", "width"),
-            coords={"height": np.arange(10), "width": np.arange(10)},
-        )
+        max_proj = _max_proj()
         positions = np.zeros((5, 2), dtype=float)
         membership = np.zeros(4, dtype=int)  # length mismatch
         adj = scipy.sparse.csr_matrix((5, 5))
@@ -37,13 +42,6 @@ class TestVisualizeSeeds:
     """Pin the seed-overlay z-order: kept (True) seeds must render on top of
     filtered-out (False) seeds so a good seed is never hidden behind a rejected
     one, regardless of the row order of the seeds dataframe."""
-
-    def _max_proj(self) -> xr.DataArray:
-        return xr.DataArray(
-            np.zeros((10, 10), dtype="float32"),
-            dims=("height", "width"),
-            coords={"height": np.arange(10), "width": np.arange(10)},
-        )
 
     def test_true_seeds_render_on_top_of_false(self):
         import holoviews as hv
@@ -62,7 +60,7 @@ class TestVisualizeSeeds:
                 "mask_good": [True, False, True, False],
             }
         )
-        ov = visualize_seeds(self._max_proj(), seeds, mask="mask_good")
+        ov = visualize_seeds(_max_proj(), seeds, mask="mask_good")
         points = ov.traverse(specs=[hv.Points])
         assert len(points) == 2
         # traverse preserves overlay (z) order; the last layer is on top.
@@ -82,7 +80,7 @@ class TestVisualizeSeeds:
 
         hv.extension("bokeh")  # .options() resolves against a loaded backend
         seeds = pd.DataFrame({"height": [1, 2], "width": [1, 2], "seeds": [5, 6]})
-        ov = visualize_seeds(self._max_proj(), seeds)
+        ov = visualize_seeds(_max_proj(), seeds)
         assert len(ov.traverse(specs=[hv.Points])) == 1
         title = hv.Store.lookup_options("bokeh", ov, "plot").kwargs.get("title")
         assert title == "seeds: 2 total"

--- a/minian/test/test_visualization.py
+++ b/minian/test/test_visualization.py
@@ -38,7 +38,7 @@ class TestVisualizeSeeds:
     filtered-out (False) seeds so a good seed is never hidden behind a rejected
     one, regardless of the row order of the seeds dataframe."""
 
-    def _max_proj(self):
+    def _max_proj(self) -> xr.DataArray:
         return xr.DataArray(
             np.zeros((10, 10), dtype="float32"),
             dims=("height", "width"),

--- a/minian/test/test_visualization.py
+++ b/minian/test/test_visualization.py
@@ -31,3 +31,55 @@ class TestVisualizeSpatialPartition:
             match="positions has 5 rows but membership has 4",
         ):
             visualize_spatial_partition(max_proj, positions, membership, adj=adj, n_frames=100)
+
+
+class TestVisualizeSeeds:
+    """Pin the seed-overlay z-order: kept (True) seeds must render on top of
+    filtered-out (False) seeds so a good seed is never hidden behind a rejected
+    one, regardless of the row order of the seeds dataframe."""
+
+    def _max_proj(self):
+        return xr.DataArray(
+            np.zeros((10, 10), dtype="float32"),
+            dims=("height", "width"),
+            coords={"height": np.arange(10), "width": np.arange(10)},
+        )
+
+    def test_true_seeds_render_on_top_of_false(self):
+        import holoviews as hv
+        import pandas as pd
+
+        from ..visualization import visualize_seeds
+
+        hv.extension("bokeh")  # .options() resolves against a loaded backend
+        # Interleave True/False so a single-layer plot would draw them in mixed
+        # order; the overlay split must still put every True seed on top.
+        seeds = pd.DataFrame(
+            {
+                "height": [1, 2, 3, 4],
+                "width": [1, 2, 3, 4],
+                "seeds": [5, 6, 7, 8],
+                "mask_good": [True, False, True, False],
+            }
+        )
+        ov = visualize_seeds(self._max_proj(), seeds, mask="mask_good")
+        points = ov.traverse(specs=[hv.Points])
+        assert len(points) == 2
+        # traverse preserves overlay (z) order; the last layer is on top.
+        bottom, top = points
+        assert top.dimension_values("mask_good").size == 2
+        assert bool(top.dimension_values("mask_good").all())  # top = kept seeds
+        assert not bool(bottom.dimension_values("mask_good").any())  # bottom = rejected
+
+    def test_unmasked_returns_single_points_layer(self):
+        import holoviews as hv
+        import pandas as pd
+
+        from ..visualization import visualize_seeds
+
+        hv.extension("bokeh")  # .options() resolves against a loaded backend
+        seeds = pd.DataFrame(
+            {"height": [1, 2], "width": [1, 2], "seeds": [5, 6]}
+        )
+        ov = visualize_seeds(self._max_proj(), seeds)
+        assert len(ov.traverse(specs=[hv.Points])) == 1

--- a/minian/visualization.py
+++ b/minian/visualization.py
@@ -1578,6 +1578,12 @@ def visualize_seeds(
         "line_alpha": 0,
     }
     im = hv.Image(max_proj, kdims=["width", "height"]).options(**opts_im)
+
+    def points(df: pd.DataFrame, color: str, vdims: list[str]) -> hv.Points:
+        return hv.Points(df, kdims=["width", "height"], vdims=vdims).options(
+            color=color, **opts_pts
+        )
+
     if mask:
         # Overlay kept (True) seeds on top of filtered-out (False) seeds so the
         # kept ones are never hidden behind a rejected point. Overlay order is
@@ -1585,19 +1591,12 @@ def visualize_seeds(
         vdims = ["seeds", mask]
         kept = seeds[seeds[mask]]
         rejected = seeds[~seeds[mask]]
-        false_pts = hv.Points(rejected, kdims=["width", "height"], vdims=vdims).options(
-            color="red", **opts_pts
-        )
-        true_pts = hv.Points(kept, kdims=["width", "height"], vdims=vdims).options(
-            color="white", **opts_pts
-        )
         # Count the same subsets that are plotted so the header can never drift.
         title = f"{mask}: {len(kept)} true (white), {len(rejected)} false (red)"
-        return (im * false_pts * true_pts).opts(title=title)
-    pts = hv.Points(seeds, kdims=["width", "height"], vdims=["seeds"]).options(
-        color="white", **opts_pts
-    )
-    return (im * pts).opts(title=f"seeds: {len(seeds)} total")
+        return (im * points(rejected, "red", vdims) * points(kept, "white", vdims)).opts(
+            title=title
+        )
+    return (im * points(seeds, "white", ["seeds"])).opts(title=f"seeds: {len(seeds)} total")
 
 
 def visualize_gmm_fit(

--- a/minian/visualization.py
+++ b/minian/visualization.py
@@ -1564,30 +1564,36 @@ def visualize_seeds(
     """
     h, w = max_proj.sizes["height"], max_proj.sizes["width"]
     asp = w / h
-    pt_cmap = {True: "white", False: "red"}
     opts_im = {"frame_width": 600, "aspect": asp, "cmap": "Viridis"}
     opts_pts = {
         "frame_width": 600,
         "aspect": asp,
-        # HoloViews >=1.16 removed size_index/color_index; map the dimensions
-        # directly instead. size_index="seeds" rendered each point with radius
-        # sqrt(base_size * seeds) where base_size = size**2 = (sqrt(6))**2 = 6
-        # (area scaling, scaling_factor=1), so reproduce it exactly here.
+        # HoloViews >=1.16 removed size_index; map the dimension directly.
+        # size_index="seeds" rendered each point with radius sqrt(base_size *
+        # seeds) where base_size = size**2 = (sqrt(6))**2 = 6 (area scaling,
+        # scaling_factor=1), so reproduce it exactly here.
         "size": (hv.dim("seeds") * 6) ** 0.5,
         "tools": ["hover"],
         "fill_alpha": 0.8,
         "line_alpha": 0,
-        "cmap": pt_cmap,
     }
+    im = hv.Image(max_proj, kdims=["width", "height"]).options(**opts_im)
     if mask:
+        # Overlay kept (True) seeds on top of filtered-out (False) seeds so the
+        # kept ones are never hidden behind a rejected point. Overlay order is
+        # z-order in HoloViews, so this is independent of seeds' row order.
         vdims = ["seeds", mask]
-        opts_pts["color"] = mask
-    else:
-        vdims = ["seeds"]
-        opts_pts["color"] = "white"
-    im = hv.Image(max_proj, kdims=["width", "height"])
-    pts = hv.Points(seeds, kdims=["width", "height"], vdims=vdims)
-    return im.options(**opts_im) * pts.options(**opts_pts)
+        false_pts = hv.Points(
+            seeds[~seeds[mask]], kdims=["width", "height"], vdims=vdims
+        ).options(color="red", **opts_pts)
+        true_pts = hv.Points(
+            seeds[seeds[mask]], kdims=["width", "height"], vdims=vdims
+        ).options(color="white", **opts_pts)
+        return im * false_pts * true_pts
+    pts = hv.Points(seeds, kdims=["width", "height"], vdims=["seeds"]).options(
+        color="white", **opts_pts
+    )
+    return im * pts
 
 
 def visualize_gmm_fit(

--- a/minian/visualization.py
+++ b/minian/visualization.py
@@ -1583,12 +1583,12 @@ def visualize_seeds(
         # kept ones are never hidden behind a rejected point. Overlay order is
         # z-order in HoloViews, so this is independent of seeds' row order.
         vdims = ["seeds", mask]
-        false_pts = hv.Points(
-            seeds[~seeds[mask]], kdims=["width", "height"], vdims=vdims
-        ).options(color="red", **opts_pts)
-        true_pts = hv.Points(
-            seeds[seeds[mask]], kdims=["width", "height"], vdims=vdims
-        ).options(color="white", **opts_pts)
+        false_pts = hv.Points(seeds[~seeds[mask]], kdims=["width", "height"], vdims=vdims).options(
+            color="red", **opts_pts
+        )
+        true_pts = hv.Points(seeds[seeds[mask]], kdims=["width", "height"], vdims=vdims).options(
+            color="white", **opts_pts
+        )
         return im * false_pts * true_pts
     pts = hv.Points(seeds, kdims=["width", "height"], vdims=["seeds"]).options(
         color="white", **opts_pts

--- a/minian/visualization.py
+++ b/minian/visualization.py
@@ -1583,17 +1583,21 @@ def visualize_seeds(
         # kept ones are never hidden behind a rejected point. Overlay order is
         # z-order in HoloViews, so this is independent of seeds' row order.
         vdims = ["seeds", mask]
-        false_pts = hv.Points(seeds[~seeds[mask]], kdims=["width", "height"], vdims=vdims).options(
+        kept = seeds[seeds[mask]]
+        rejected = seeds[~seeds[mask]]
+        false_pts = hv.Points(rejected, kdims=["width", "height"], vdims=vdims).options(
             color="red", **opts_pts
         )
-        true_pts = hv.Points(seeds[seeds[mask]], kdims=["width", "height"], vdims=vdims).options(
+        true_pts = hv.Points(kept, kdims=["width", "height"], vdims=vdims).options(
             color="white", **opts_pts
         )
-        return im * false_pts * true_pts
+        # Count the same subsets that are plotted so the header can never drift.
+        title = f"{mask}: {len(kept)} true (white), {len(rejected)} false (red)"
+        return (im * false_pts * true_pts).opts(title=title)
     pts = hv.Points(seeds, kdims=["width", "height"], vdims=["seeds"]).options(
         color="white", **opts_pts
     )
-    return im * pts
+    return (im * pts).opts(title=f"seeds: {len(seeds)} total")
 
 
 def visualize_gmm_fit(


### PR DESCRIPTION
## What

Make `visualize_seeds` always render kept (True) seeds **on top of** filtered-out (False) seeds.

## Why

Follow-up to #340. `visualize_seeds` plotted every seed as a single `hv.Points` layer, colored by the mask column (True = white/kept, False = red/rejected). With one layer, the draw order is just the seeds dataframe's row order, so after a refinement step a rejected (red) seed can land on top of and hide a kept (white) seed. There was no guarantee that good seeds stayed visible.

## Change

Split the masked path into two overlaid `Points` layers, filtered-out seeds first and kept seeds last:

```python
return im * false_pts * true_pts
```

Overlay order is the only contractual z-order in HoloViews (within-layer row order is backend-dependent), so kept seeds are now reliably on top regardless of dataframe order or backend. Per-layer fixed colors replace the `cmap`/`pt_cmap` mapping. The unmasked path keeps its single white layer. Point sizing (`size_index` reproduction from #340) and hover are unchanged.

## Tests

Added `TestVisualizeSeeds` pinning that the top `Points` layer contains only the kept (True) seeds and the bottom only the rejected (False) seeds, with interleaved input so a single-layer plot would mix them. Also covers the unmasked single-layer case. All pass locally on HoloViews 1.23 / bokeh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview minian start -->
----
📚 Documentation preview 📚: https://minian--343.org.readthedocs.build/en/343/

<!-- readthedocs-preview minian end -->