### PR TITLE
perf(float32): make the data path float32 at its source

### DIFF
--- a/minian/io.py
+++ b/minian/io.py
@@ -40,7 +40,7 @@ def _ensure_ffmpeg() -> None:
 def load_videos(
     vpath: str,
     pattern: str = r"msCam[0-9]+\.avi$",
-    dtype: str | type = np.float64,
+    dtype: str | type = np.float32,
     downsample: dict | None = None,
     downsample_strategy: str = "subset",
     post_process: Callable | None = None,
@@ -64,7 +64,9 @@ def load_videos(
         `r"msCam[0-9]+\.avi$"`, which can be interpreted as filenames starting
         with "msCam" followed by at least a number, and then followed by ".avi".
     dtype : Union[str, type], optional
-        Datatype of the resulting DataArray, by default `np.float64`.
+        Datatype of the resulting DataArray, by default `np.float32`. The source
+        footage is 8-bit, so its values are represented exactly in `float32`
+        while halving memory and on-disk size relative to `float64`.
     downsample : dict, optional
         A dictionary mapping dimension names to an integer downsampling factor.
         The dimension names should be one of "height", "width" or "frame". By

--- a/minian/notebooks/pipeline/pipeline.ipynb
+++ b/minian/notebooks/pipeline/pipeline.ipynb
@@ -1199,7 +1199,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "Y_fm_chk = save_minian(Y.astype(float).rename(\"Y_fm_chk\"), intpath, overwrite=True)\n",
+    "Y_fm_chk = save_minian(Y.astype(np.float32).rename(\"Y_fm_chk\"), intpath, overwrite=True)\n",
     "Y_hw_chk = save_minian(\n",
     "    Y_fm_chk.rename(\"Y_hw_chk\"),\n",
     "    intpath,\n",


### PR DESCRIPTION
## What

Phase 1 of moving minian off `float64`: switch the **data path to `float32` at its source**. Because dask/xarray/numpy infer output dtype from their inputs, flipping the source is enough for the bulk of the pipeline to follow.

Two changes:

1. **`io.load_videos` default `np.float64` -> `np.float32`.** The footage is 8-bit, so every loaded value is represented *exactly* in `float32` (no precision loss at load), while halving memory and on-disk size. Callers that pass `dtype` explicitly - including the demo notebook (`uint8`) and every test - are unaffected.
2. **Pipeline notebook: `Y.astype(float)` -> `Y.astype(np.float32)`** at the `Y_fm_chk` save. This was the *single* spot promoting the demo movie to `float64` - the ~69 GB-vs-34 GB cube behind the slow save/rechunk in #342. Everything downstream (`Y_fm_chk`, `Y_hw_chk`, seed init, CNMF prep) is now `float32`; all other notebook casts were already `float32`.

## Scope (deliberately limited)

This PR only changes the data **source**. The CNMF gufunc `output_dtypes` in `cnmf.py` still emit `float64`, and sklearn `LassoLars` / cvxpy solvers upcast internally, so numeric results shift only as much as a `float32` input warrants. Tightening those (gufunc `output_dtypes`, internal `np.zeros` dtypes, double accumulators) is a validated follow-up (Phase 2).

## Validation

`test_pipeline_notebook` runs this notebook end-to-end in CI and checks cell count (`286 ±10`) and the C/S/A sums (`rel 5e-2 / 1e-1 / 5e-2`) - tolerances built for exactly this kind of numeric drift. That's the gate for the notebook change. The `io` default change is covered by `test_pre_processing` (which passes `dtype` explicitly, so behavior is unchanged there).

## Note

Targets `master`, which is the v2 development branch, so the `load_videos` default dtype change (a public-API default change suited to a major version) is appropriate here. It's also backward-compatible for 8-bit-sourced data, since those values are exact in float32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
