### PR TITLE
test(motion): pin the centering offset, not just the shape

### DIFF
--- a/minian/test/test_motion_correction.py
+++ b/minian/test/test_motion_correction.py
@@ -10,9 +10,15 @@ Two tiers, both fast enough to run every CI cycle (the heavy notebook golden in
 * **Ground truth** - the full :func:`estimate_motion` / :func:`apply_transform`
   path against a minisim recording that ships the exact applied motion. The
   estimate is the *correction*, i.e. the negation of ``GroundTruth.shifts``, so it
-  is scored with :func:`minisim.shift_rmse` (``correction=True``); ``align=True``
-  absorbs the constant offset between the pipeline's registration template and
-  minisim's zero-shift reference. See :mod:`minian.test._simulated`.
+  is scored with :func:`minisim.shift_rmse` (``correction=True``). The motion is
+  checked along two independent axes: a **shape** test with ``align=True`` (does
+  the correction track the motion, ignoring origin) and an **offset** test (is the
+  constant gap between correction and motion exactly the shift that re-centers the
+  ground truth to zero mean). minisim anchors its ground truth at frame 0 while
+  minian centers its shifts to zero mean (smallest corrected bounding box), so the
+  two carry a constant offset; ``align`` deliberately absorbs it in the shape test,
+  and the offset test pins it down so a regression that lets the shifts run off
+  cannot hide behind ``align``. See :mod:`minian.test._simulated`.
 """
 
 import numpy as np
@@ -96,18 +102,39 @@ def test_transform_perframe_translates_by_the_given_shift():
 # --- ground truth: estimate_motion / apply_transform vs minisim -------------
 #
 # Tolerances reflect measured sub-pixel recovery on this fixture (aligned RMSE
-# ~0.03-0.05 px on the well-separated somata make_recording plants); the 1.0 px
-# bound leaves wide headroom for seed/platform variation while still failing loudly
-# on a real regression.
+# ~0.03 px on the well-separated somata make_recording plants, and the per-axis
+# centering offset ~0.06-0.15 px); the bounds leave ~8x headroom for seed/platform
+# variation while still failing loudly on a real regression.
 
-_RMSE_TOL_PX = 1.0
+_RMSE_TOL_PX = 0.25
+_OFFSET_TOL_PX = 0.5
 
 
 def test_estimate_motion_recovers_random_walk(simulated_recording):
+    # Shape: with align=True the constant origin offset is absorbed, so this scores
+    # purely how well the correction tracks the motion. The offset it ignores is
+    # checked separately by test_estimate_motion_offset_is_ground_truth_mean.
     rec = simulated_recording([BrainMotion(model="walk", walk_step_um=1.5, max_shift_um=10.0)])
     est = estimate_motion(as_movie(rec)).compute()
     rmse = shift_rmse(est.values, rec.ground_truth.shifts, correction=True, align=True)
     assert rmse < _RMSE_TOL_PX
+
+
+def test_estimate_motion_offset_is_ground_truth_mean(simulated_recording):
+    # Offset: the shape test's align=True throws away the constant gap between
+    # minian's zero-mean-centered correction and minisim's frame-0-anchored motion.
+    # That gap is not free though - it is exactly the shift that re-centers the
+    # ground truth to zero mean. Compute both and require they match, so a regression
+    # that stops centering and lets the shifts run off (a large static offset, hence
+    # needless cropping or padding) fails loudly instead of hiding behind align.
+    rec = simulated_recording([BrainMotion(model="walk", walk_step_um=1.5, max_shift_um=10.0)])
+    gt = rec.ground_truth.shifts
+    est = estimate_motion(as_movie(rec)).compute()
+    # est is the correction (negation of the applied motion), so the per-axis mean of
+    # (-est - gt) is the constant offset minian introduced relative to the motion.
+    measured_offset = (-est.values - gt).mean(axis=0)
+    zero_mean_offset = -gt.mean(axis=0)
+    np.testing.assert_allclose(measured_offset, zero_mean_offset, atol=_OFFSET_TOL_PX)
 
 
 def test_estimate_motion_recovers_known_trajectory(simulated_recording):


### PR DESCRIPTION
Closes #345.

## Background

#345  pointed out that the ground-truth motion tests scored only with `shift_rmse(..., align=True)`. `align` subtracts the per-axis mean residual before the RMSE, which is the correct way to compare two trajectories with different origins, but it means the suite was a pure **shape** (correlation) check. A regression that stopped centering and let the shifts run off to a large static offset would crop or pad the corrected video needlessly yet still pass.

## What's actually happening (not a motion-correction bug)

minisim anchors its ground truth at frame 0 = (0,0) and lets the motion drift from there, so the trajectory generally has a nonzero mean. minian does the opposite: it centers the estimated shifts to zero mean (`est_motion_chunk`, `motions -= motions.mean(axis=0)`), specifically to keep the corrected video's bounding box minimal. So the two use different zero points, and the constant gap between them is just the mean of minisim's walk. That is also why the gap scales with motion: a bigger walk has a bigger mean displacement. The slope-1 correlation in the issue confirms registration tracks the motion correctly; only the origin differs.

Verified on the fixture: minian's estimate is essentially zero-mean (`|mean(est)|` ~0.06-0.15 px) and `max|est|` stays bounded by the motion range, so nothing is running off.

## Change

Two independent tests, per the plan in #345:

- **Shape** (existing `test_estimate_motion_recovers_random_walk`): keep `align=True`, which is the right tool here. Tolerance tightened from 1.0 to 0.25 px (measured aligned RMSE ~0.03 px), so the threshold is no longer ~30x too generous.
- **Offset** (new `test_estimate_motion_offset_is_ground_truth_mean`): compute the shift that re-centers the ground truth to zero mean, and require the constant gap between minian's correction and the applied motion to equal it within 0.5 px (measured ~0.06-0.15 px). A runaway offset now fails loudly instead of hiding behind `align`.

Splitting the two means that if CI ever goes red, it says whether registration drifted (shape) or centering broke (offset).

All 14 tests in `test_motion_correction.py` pass locally; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview minian start -->
----
📚 Documentation preview 📚: https://minian--346.org.readthedocs.build/en/346/

<!-- readthedocs-preview minian end -->